### PR TITLE
Remove unnecessary logging statement

### DIFF
--- a/app/io/flow/event/Queue.scala
+++ b/app/io/flow/event/Queue.scala
@@ -218,9 +218,6 @@ case class KinesisStream(
         .withShardId(shardId)
         .withStreamName(name)
 
-      // for sanity
-      Logger.info(s"Stream: $name, Shard Sequence Number Map: $shardSequenceNumberMap")
-
       val request = shardSequenceNumberMap.contains(shardId) match {
         case true => {
           baseRequest


### PR DESCRIPTION
This was originally used to troubleshoot lib-event when it was being built, but is largely useless and can be really noisy these days