### PR TITLE
ensure UTF-8 character encoding on published message

### DIFF
--- a/app/io/flow/event/Queue.scala
+++ b/app/io/flow/event/Queue.scala
@@ -98,7 +98,7 @@ case class KinesisStream(
     try {
       client.putRecord(
         new PutRecordRequest()
-          .withData(ByteBuffer.wrap(data.getBytes))
+          .withData(ByteBuffer.wrap(data.getBytes("UTF-8")))
           .withPartitionKey(partitionKey)
           .withStreamName(name)
       )


### PR DESCRIPTION
Default char encoding in Docker container is `ANSI_X3.4-1968`.  So, deserializing message content without enforcing character encoding yields `?` for some characters, namely currency symbols.

```
scala> "€".getBytes("UTF-8")
res18: Array[Byte] = Array(-30, -126, -84)

scala> "€".getBytes("ANSI_X3.4-1968")
res19: Array[Byte] = Array(63)

 scala> "?".getBytes
res20: Array[Byte] = Array(63)
```