### PR TITLE
bump aws-java-sdk-s3 1.11.45=>1.11.46

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ lazy val root = project
     libraryDependencies ++= Seq(
       ws,
       "io.flow" %% "lib-play" % "0.2.1",
-      "com.amazonaws" % "aws-java-sdk-kinesis" % "1.11.45",
+      "com.amazonaws" % "aws-java-sdk-kinesis" % "1.11.46",
       "org.scalatestplus" %% "play" % "1.4.0" % "test"
     ),
     resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/",


### PR DESCRIPTION
Note: **not** publishing