### PR TITLE
put AWS CloudWatch metric on record consumption - stream latency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,8 @@ lazy val root = project
     libraryDependencies ++= Seq(
       ws,
       "io.flow" %% "lib-play" % "0.2.2",
-      "com.amazonaws" % "aws-java-sdk-kinesis" % "1.11.47",
+      "com.amazonaws" % "aws-java-sdk-cloudwatch" % "1.11.48",
+      "com.amazonaws" % "aws-java-sdk-kinesis" % "1.11.48",
       "org.scalatestplus" %% "play" % "1.4.0" % "test"
     ),
     resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/",


### PR DESCRIPTION
Put custom metric in AWS CloudWatch when consuming messages from each stream/shard indicating "time lived" in the stream itself (from arrival to consumption).

Metrics are created:
![stream-latency](https://cloud.githubusercontent.com/assets/4163067/19741115/7a29a5b4-9b8d-11e6-86b6-dd2bbe19eeb9.gif)

Custom metrics will appear like this:
![screen shot 2016-10-26 at 2 52 05 pm](https://cloud.githubusercontent.com/assets/4163067/19740492/db393226-9b8c-11e6-8e92-143c1378a65e.png)

Then, we can customize and add to new (or existing) dashboards:
https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#dashboards:name=Stream-Throughput