### PR TITLE
instatiate ClientConfiguration with maxRetry

### DIFF
--- a/app/io/flow/event/Queue.scala
+++ b/app/io/flow/event/Queue.scala
@@ -7,12 +7,16 @@ import com.amazonaws.services.kinesis.AmazonKinesisClient
 import com.amazonaws.services.kinesis.model._
 import play.api.libs.json.{JsValue, Json}
 import play.api.Logger
+
 import scala.reflect.runtime.universe._
 import scala.concurrent.ExecutionContext
 import scala.util.{Failure, Success, Try}
 import java.nio.ByteBuffer
+
+import com.amazonaws.ClientConfiguration
 import org.joda.time.DateTime
 import org.joda.time.format.ISODateTimeFormat.dateTimeParser
+
 import collection.JavaConverters._
 
 trait Queue {
@@ -70,8 +74,13 @@ class KinesisQueue @javax.inject.Inject() (
     config.requiredString("aws.secret.key")
   )
 
+  private[this] val clientConfig =
+    new ClientConfiguration()
+      .withMaxErrorRetry(5)
+      .withThrottledRetries(true)
+
   private[this] val numberShards = 1
-  private[this] val kinesisClient = new AmazonKinesisClient(credentials)
+  private[this] val kinesisClient = new AmazonKinesisClient(credentials, clientConfig)
 
   var kinesisStreams: scala.collection.mutable.Map[String, KinesisStream] = scala.collection.mutable.Map[String, KinesisStream]()
 


### PR DESCRIPTION
Issue:
```
Error was: null (Service: AmazonKinesis; Status Code: 500; Error Code: InternalFailure; Request ID: f2c765fb-7724-5955-a261-cb9ed1e56371)
```

Include `ClientConfiguration` and explicitly set number of retries -
Documentation:
http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/ClientConfiguration.html#setMaxErrorRetry-int-

AWS Ticket:
https://console.aws.amazon.com/support/home?region=us-east-1#/case/?displayId=1949359351&language=en