### PR TITLE
bump aws-java-sdk-kinesis 1..167 => 1.11.68

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ lazy val root = project
     libraryDependencies ++= Seq(
       ws,
       "io.flow" %% "lib-play" % "0.2.8",
-      "com.amazonaws" % "aws-java-sdk-kinesis" % 1.11.67,
+      "com.amazonaws" % "aws-java-sdk-kinesis" % 1.11.68,
       "org.scalatestplus" %% "play" % "1.4.0" % "test"
     ),
     resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/",


### PR DESCRIPTION
**NOTE**: bumping but not releasing (not necessary)