### PR TITLE
to alleviate ExpiredIteratorException in getRecords, ensure cache is updated with latest shard iterator

### DIFF
--- a/app/io/flow/event/Queue.scala
+++ b/app/io/flow/event/Queue.scala
@@ -363,7 +363,10 @@ case class KinesisStream(
 
     val nextShardIterator = (millisBehindLatest == 0) match {
       case true => None
-      case false => Some(result.getNextShardIterator)
+      case false =>
+        val nextShardItr= result.getNextShardIterator
+        shardIteratorMap += (shardId -> ShardIterator(shardIterator = nextShardItr, timestamp = DateTime.now()))
+        Some(result.getNextShardIterator)
     }
 
     KinesisShardMessageSummary(messages, nextShardIterator)

--- a/app/io/flow/event/Queue.scala
+++ b/app/io/flow/event/Queue.scala
@@ -364,7 +364,7 @@ case class KinesisStream(
     val nextShardIterator = (millisBehindLatest == 0) match {
       case true => None
       case false =>
-        val nextShardItr= result.getNextShardIterator
+        val nextShardItr = result.getNextShardIterator
         shardIteratorMap += (shardId -> ShardIterator(shardIterator = nextShardItr, timestamp = DateTime.now()))
         Some(result.getNextShardIterator)
     }


### PR DESCRIPTION
Fix referencing this error:

```
{"log":"[\u001b[31merror\u001b[0m] application - FlowKinesisError Stream[production.currency.internal.event.v0.currency_internal_event.json]
ExpiredIteratorException calling [io.flow.event.getRecords].
Error Message: Iterator expired.
The iterator was created at time Wed Dec 21 21:40:40 UTC 2016 while right now it is Wed Dec 21 21:46:07 UTC 2016 which is further in the future than the tolerated delay of 300000 milliseconds.
(Service: AmazonKinesis; Status Code: 400; Error Code: ExpiredIteratorException; Request ID: dcae3436-a1e8-02b9-8c7a-ce69f72d0b71)\n","stream":"stdout","time":"2016-12-21T21:46:07.302609866Z"}
Host: localhost
Name: /var/lib/docker/containers/375cee1bb7cec107fd727578a05c4e40f4845dae732fc922ddf6f630b73a424f/375cee1bb7cec107fd727578a05c4e40f4845dae732fc922ddf6f630b73a424f-json.log
Category: experience_docker_logs
```