### PR TITLE
print stacktrace to gather further details on generic kinesis errors

### DIFF
--- a/app/io/flow/event/Queue.scala
+++ b/app/io/flow/event/Queue.scala
@@ -407,6 +407,8 @@ case class KinesisStream(
             Logger.error(msg)
             throw new Exception(msg, ex)
           case ex: Throwable => {
+            ex.printStackTrace(System.err)
+            
             val msg = s"FlowKinesisError Stream [$name] Failed in [io.flow.event.$methodName].  Error was: ${ex.getMessage}"
             Logger.error(msg)
             throw new Exception(msg, ex)


### PR DESCRIPTION
to help further troubleshoot errors like - 

```
{"log":"java.lang.Exception: FlowKinesisError Stream [production.catalog.event.v0.catalog_event.json]
Failed in [io.flow.event.getRecords].
Error was: Unable to execute HTTP request: kinesis.us-east-1.amazonaws.com\n","stream":"stdout","time":"2016-12-21T20:03:48.903476399Z"}
Host: localhost
Name: /var/lib/docker/containers/f9dba17ce5764126bd4b8602c83ee76a4dc75f156dfa803200543152a0d6e446/f9dba17ce5764126bd4b8602c83ee76a4dc75f156dfa803200543152a0d6e446-json.log
Category: metric_docker_logs
```

- Need to determine if this is due to a timeout, and if so, what kind of timeout