### PR TITLE
set connection TTL to create new kinesis client connection

### DIFF
--- a/app/io/flow/event/Queue.scala
+++ b/app/io/flow/event/Queue.scala
@@ -92,6 +92,7 @@ class KinesisQueue @javax.inject.Inject() (
     new ClientConfiguration()
       .withMaxErrorRetry(5)
       .withThrottledRetries(true)
+      .withConnectionTTL(60000)
 
   private[this] val numberShards = 1
   private[this] val kinesisClient = new AmazonKinesisClient(credentials, clientConfig)


### PR DESCRIPTION
attempt to help alleviate the following error:

```
{"log":"java.lang.Exception: FlowKinesisError Stream [production.catalog.event.v0.catalog_event.json]
Failed in [io.flow.event.getRecords].
Error was: Unable to execute HTTP request: kinesis.us-east-1.amazonaws.com\n","stream":"stdout","time":"2016-12-21T20:03:48.903476399Z"}
Host: localhost
Name: /var/lib/docker/containers/f9dba17ce5764126bd4b8602c83ee76a4dc75f156dfa803200543152a0d6e446/f9dba17ce5764126bd4b8602c83ee76a4dc75f156dfa803200543152a0d6e446-json.log
Category: metric_docker_logs
```

indicators that point to requiring a new connection (from the stack trace) are - 

```
{"log":"\u0009at org.apache.http.impl.conn.PoolingHttpClientConnectionManager.connect(PoolingHttpClientConnectionManager.java:353)\n","stream":"stdout","time":"2017-01-03T12:57:49.093990615Z"}
```

```
{"log":"\u0009at com.amazonaws.SystemDefaultDnsResolver.resolve(SystemDefaultDnsResolver.java:27)\n","stream":"stdout","time":"2017-01-03T12:57:49.09398287Z"}
```

Doc reference:
```
    /**
     * Sets the expiration time (in milliseconds) for a connection in the connection pool. When
     * retrieving a connection from the pool to make a request, the total time that the connection
     * has been open is compared against this value. Connections which have been open for longer are
     * discarded, and if needed a new connection is created.
     * <p>
     * Tuning this setting down (together with an appropriately-low setting for Java's DNS cache
     * TTL) ensures that your application will quickly rotate over to new IP addresses when the
     * service begins announcing them through DNS, at the cost of having to re-establish new
     * connections more frequently.
     * <p>
     * By default, it is set to {@code -1}, i.e. connections do not expire.
     *
     * @param connectionTTL
     *            the connection TTL, in milliseconds
     * @return the updated ClientConfiguration object
     */
```