### PR TITLE
reduce noise when PSQL error on partition table

### DIFF
--- a/test/regex/RegexSpec.scala
+++ b/test/regex/RegexSpec.scala
@@ -1,0 +1,20 @@
+package io.flow.event
+
+
+import org.scalatestplus.play.{PlaySpec, OneAppPerSuite}
+
+class RegexSpec extends PlaySpec with OneAppPerSuite {
+
+  "match on a partition table name" in {
+    val msg = "blah blah duplicate key value violates unique constraint \"inventory_event_p2017_01_12_pkey blah blah"
+
+    msg.matches(".*duplicate key value violates unique constraint.*_p\\d{4}_\\d{2}_\\d{2}_pkey.*") must equal(true)
+
+
+
+    val msg2 = "blah blah duplicate key value violates unique constraint \"cool_posts_pkey blah blah"
+
+    msg2.matches(".*duplicate key value violates unique constraint.*_p\\d{4}_\\d{2}_\\d{2}_pkey.*") must equal(false)
+  }
+
+}


### PR DESCRIPTION
For example, the following regex would match the following:
![screen shot 2017-01-12 at 5 30 43 pm](https://cloud.githubusercontent.com/assets/4163067/21911073/ee21c162-d8ec-11e6-970a-d46ff76e1f77.png)
