### PR TITLE
fix bug in MockQueue to return MockStream

### DIFF
--- a/app/io/flow/event/Queue.scala
+++ b/app/io/flow/event/Queue.scala
@@ -454,7 +454,7 @@ class MockQueue extends Queue {
 
   var mockStreams: scala.collection.mutable.Map[String, MockStream] = scala.collection.mutable.Map[String, MockStream]()
 
-  override def stream[T: TypeTag](implicit ec: ExecutionContext): Stream = {
+  override def stream[T: TypeTag](implicit ec: ExecutionContext): MockStream = {
     val name = typeOf[T].toString
 
     if (!mockStreams.contains(name))


### PR DESCRIPTION
tests that depend on this mock are incorrectly calling 

`Stream` publish/consume methods here (https://github.com/flowcommerce/lib-event/blob/master/app/io/flow/event/Queue.scala#L26-L29) 

and not the ones in 

`MockStream` here (https://github.com/flowcommerce/lib-event/blob/master/app/io/flow/event/Queue.scala#L472-L492)



