### PR TITLE
No need for stack track on dupe key/id exceptions on event queue tables

### DIFF
--- a/app/io/flow/event/actors/PollActor.scala
+++ b/app/io/flow/event/actors/PollActor.scala
@@ -80,7 +80,7 @@ trait PollActor extends Actor with ActorLogging with ErrorHandler {
 
                 // explicitly catch and only warn on duplicate key value constraint errors on partitioned tables
                 if (PollActor.filterExceptionMessage(ex.getMessage)) {
-                  Logger.warn(s"[${self.getClass.getName}] FlowEventWarning Error processing record: ${ex.getMessage}", ex)
+                  Logger.warn(s"[${self.getClass.getName}] FlowEventWarning Error processing record: ${ex.getMessage}")
                 } else {
                   Logger.error(s"[${self.getClass.getName}] FlowEventError Error processing record: ${ex.getMessage}", ex)
                 }

--- a/app/io/flow/event/v2/actors/PollActor.scala
+++ b/app/io/flow/event/v2/actors/PollActor.scala
@@ -87,7 +87,7 @@ trait PollActor extends Actor with ActorLogging with ErrorHandler {
         // explicitly catch and only warn on duplicate key value constraint errors on partitioned tables
         // which is a work around to on conflict not working for child partition tables
         if (PollActorErrors.filterExceptionMessage(ex.getMessage)) {
-          Logger.warn(s"[${this.getClass.getName}] FlowEventWarning Error processing record: ${ex.getMessage}", ex)
+          Logger.warn(s"[${this.getClass.getName}] FlowEventWarning Error processing record: ${ex.getMessage}")
         } else {
           val msg = s"[${this.getClass.getName}] FlowEventError Error processing record: ${ex.getMessage}"
           Logger.error(msg)


### PR DESCRIPTION
Creates a lot of unnecessary logging into Sumo from the services, which eats up into our monthly allocations