### PR TITLE
Improve mock queue + fix default queue

### DIFF
--- a/app/io/flow/event/v2/Queue.scala
+++ b/app/io/flow/event/v2/Queue.scala
@@ -84,7 +84,7 @@ class DefaultQueue @Inject() (
   }
 
   override def shutdownConsumers(implicit ec: ExecutionContext): Unit = {
-    // synchronized to avoid a consumer being registered "in between" the shutdown and the clear
+    // synchronized to avoid a consumer being registered "in between" shutdown and clear
     synchronized {
       consumers.asScala.foreach(_.shutdown)
       consumers.clear()


### PR DESCRIPTION
Add capabilities to the mock queue:
 - shutdown consumers
 - clear pending

Also add a small concurrency fix to the `DefaultQueue`