### PR TITLE
Upgrade libraries: io.flow, org.scalatestplus.play

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,9 +15,9 @@ lazy val root = project
     testOptions += Tests.Argument("-oF"),
     libraryDependencies ++= Seq(
       ws,
-      "io.flow" %% "lib-play" % "0.3.35",
+      "io.flow" %% "lib-play" % "0.4.0",
       "com.amazonaws" % "amazon-kinesis-client" % "1.8.1",
-      "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.1" % "test",
+      "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % "test",
       "org.mockito" % "mockito-core" % "2.10.0" % "test"
     ),
     resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/",


### PR DESCRIPTION
- io.flow
    - lib-play (0.3.35 => 0.4.0)
  - org.scalatestplus.play
    - scalatestplus-play (3.1.1 => 3.1.2)