### PR TITLE
Add consumer batch

### DIFF
--- a/app/io/flow/event/v2/MockQueue.scala
+++ b/app/io/flow/event/v2/MockQueue.scala
@@ -26,7 +26,7 @@ class MockQueue @Inject()() extends Queue {
   }
 
   override def consume[T: TypeTag](
-    f: Record => Unit,
+    f: Seq[Record] => Unit,
     pollTime: FiniteDuration = FiniteDuration(20, MILLISECONDS)
   )(
     implicit ec: ExecutionContext
@@ -68,10 +68,10 @@ class MockQueue @Inject()() extends Queue {
 
 }
 
-case class RunningConsumer(stream: MockStream, action: Record => Unit, pollTime: FiniteDuration) {
+case class RunningConsumer(stream: MockStream, action: Seq[Record] => Unit, pollTime: FiniteDuration) {
 
   private val runnable = new Runnable() {
-    override def run(): Unit = stream.consume().foreach(action)
+    override def run(): Unit = stream.consume().foreach(e => action(Seq(e)))
   }
 
   private val ses = Executors.newSingleThreadScheduledExecutor()

--- a/app/io/flow/event/v2/Queue.scala
+++ b/app/io/flow/event/v2/Queue.scala
@@ -24,11 +24,9 @@ trait Queue {
     * invoking your provided function for each new record
     */
   def consume[T: TypeTag](
-    f: Record => Unit,
+    f: Seq[Record] => Unit,
     pollTime: FiniteDuration = FiniteDuration(5, "seconds")
-  )(
-    implicit ec: ExecutionContext
-  )
+  )(implicit ec: ExecutionContext)
 
   def shutdown(implicit ec: ExecutionContext)
 
@@ -72,11 +70,9 @@ class DefaultQueue @Inject() (
   }
 
   override def consume[T: TypeTag](
-     f: Record => Unit,
+     f: Seq[Record] => Unit,
      pollTime: FiniteDuration = FiniteDuration(5, "seconds")
-  )(
-     implicit ec: ExecutionContext
-  ) {
+  )(implicit ec: ExecutionContext) {
     consumers.add(
       KinesisConsumer(
         streamConfig[T],

--- a/app/io/flow/event/v2/actors/PollActor.scala
+++ b/app/io/flow/event/v2/actors/PollActor.scala
@@ -1,15 +1,9 @@
 package io.flow.event.actors.v2
 
-import akka.actor.{Actor, ActorLogging, ActorSystem}
 import io.flow.event.Record
-import io.flow.event.v2.{MockQueue, Queue}
-import io.flow.play.actors.ErrorHandler
-import play.api.Logger
+import io.flow.event.v2.actors.PollActorBatch
 
-import scala.concurrent.ExecutionContext
-import scala.concurrent.duration._
-import scala.reflect.runtime.universe.TypeTag
-import scala.util.{Failure, Success, Try}
+import scala.util.Try
 
 /**
   * Poll Actor periodically polls a kinesis stream (by default every 5
@@ -19,88 +13,12 @@ import scala.util.{Failure, Success, Try}
   *   - implement system, queue, process(record)
   *   - call start(...) w/ the name of the execution context to use
   */
-trait PollActor extends Actor with ActorLogging with ErrorHandler {
+trait PollActor extends PollActorBatch {
 
-  /**
-    * Called once for every event read off the stream
-    */
-  def process(record: Record)
-
-  /**
-    * Called once for every event read off the stream - if true,
-    * we then call process(record). Override this method to
-    * filter specific records to process
-    */
-  def accepts(record: Record): Boolean = {
-    true
+  override def processBatch(records: Seq[Record]): Unit = {
+    records.map(r => Try(process(r)))
   }
 
-  def system: ActorSystem
+  def process(record: Record): Unit
 
-  def queue: Queue
-
-  private[this] implicit var ec: ExecutionContext = _
-
-  private[this] def defaultDuration = {
-    queue match {
-      case _:  MockQueue => FiniteDuration(20, MILLISECONDS)
-      case _ => FiniteDuration(5, SECONDS)
-    }
-  }
-
-  def start[T: TypeTag](
-    executionContextName: String,
-    pollTime: FiniteDuration = defaultDuration
-  ) {
-    val ec = system.dispatchers.lookup(executionContextName)
-    startWithExecutionContext(ec, pollTime)
-  }
-
-  def startWithExecutionContext[T: TypeTag](
-    executionContext: ExecutionContext,
-    pollTime: FiniteDuration = FiniteDuration(5, SECONDS)
-  ) {
-    Logger.info(s"[${getClass.getName}] Scheduling poll every $pollTime")
-
-    this.ec = executionContext
-
-    queue.consume[T](
-      pollTime = pollTime,
-      f = processWithErrorHandler
-    )
-  }
-
-  override def receive: Receive = {
-    case msg: Any => logUnhandledMessage(msg)
-  }
-
-  def processWithErrorHandler(record: Record) {
-    Try {
-      if (accepts(record)) {
-        process(record)
-      }
-    } match {
-      case Success(_) => // no-op
-      case Failure(ex) => {
-        ex.printStackTrace(System.err)
-
-        // explicitly catch and only warn on duplicate key value constraint errors on partitioned tables
-        // which is a work around to on conflict not working for child partition tables
-        if (PollActorErrors.filterExceptionMessage(ex.getMessage)) {
-          Logger.warn(s"[${this.getClass.getName}] FlowEventWarning Error processing record: ${ex.getMessage}")
-        } else {
-          val msg = s"[${this.getClass.getName}] FlowEventError Error processing record: ${ex.getMessage}"
-          Logger.error(msg)
-          throw new RuntimeException(msg, ex)
-        }
-      }
-    }
-  }
-}
-
-object PollActorErrors {
-  /** Checks whether the first line of an exception message matches a partman partitioning error, which is not critical. */
-  def filterExceptionMessage(message: String): Boolean = {
-    message.split("\\r?\\n").headOption.exists(_.matches(".*duplicate key value violates unique constraint.*_p\\d{4}_\\d{2}_\\d{2}_pkey.*"))
-  }
 }

--- a/app/io/flow/event/v2/actors/PollActorBatch.scala
+++ b/app/io/flow/event/v2/actors/PollActorBatch.scala
@@ -1,0 +1,98 @@
+package io.flow.event.v2.actors
+
+import akka.actor.{Actor, ActorLogging, ActorSystem}
+import io.flow.event.Record
+import io.flow.event.v2.{MockQueue, Queue}
+import io.flow.play.actors.ErrorHandler
+import play.api.Logger
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration.{FiniteDuration, MILLISECONDS, SECONDS}
+import scala.reflect.runtime.universe.TypeTag
+import scala.util.{Failure, Success, Try}
+
+
+
+/**
+  * [[PollActorBatch]] periodically polls a kinesis stream invoking process once per message batch
+  *
+  * To extend this class:
+  *   - implement required methods
+  *   - call start(...) w/ the name of the execution context to use
+  */
+trait PollActorBatch extends Actor with ActorLogging with ErrorHandler {
+
+  /**
+    * Called once for every batch read off the stream
+    */
+  def processBatch(records: Seq[Record]): Unit
+
+  /**
+    * Called once for every event read off the stream - if true,
+    * we then call process(record). Override this method to
+    * filter specific records to process
+    */
+  def accepts(record: Record): Boolean = true
+
+  def system: ActorSystem
+
+  def queue: Queue
+
+  private[this] implicit var ec: ExecutionContext = _
+
+  private[this] def defaultDuration = {
+    queue match {
+      case _:  MockQueue => FiniteDuration(20, MILLISECONDS)
+      case _ => FiniteDuration(5, SECONDS)
+    }
+  }
+
+  def start[T: TypeTag](
+                         executionContextName: String,
+                         pollTime: FiniteDuration = defaultDuration
+                       ) {
+    val ec = system.dispatchers.lookup(executionContextName)
+    startWithExecutionContext(ec, pollTime)
+  }
+
+  def startWithExecutionContext[T: TypeTag](
+                                             executionContext: ExecutionContext,
+                                             pollTime: FiniteDuration = FiniteDuration(5, SECONDS)
+                                           ) {
+    Logger.info(s"[${getClass.getName}] Scheduling poll every $pollTime")
+
+    this.ec = executionContext
+
+    queue.consume[T](
+      pollTime = pollTime,
+      f = processWithErrorHandler
+    )
+  }
+
+  override def receive: Receive = {
+    case msg: Any => logUnhandledMessage(msg)
+  }
+
+  private def processWithErrorHandler(records: Seq[Record]): Unit = {
+    Try {
+      val filteredRecords = records.filter(accepts)
+      if (filteredRecords.nonEmpty)
+        processBatch(filteredRecords)
+    } match {
+      case Success(res) => // no-op
+      case Failure(ex) => {
+        ex.printStackTrace(System.err)
+
+        // explicitly catch and only warn on duplicate key value constraint errors on partitioned tables
+        // which is a work around to on conflict not working for child partition tables
+        if (PollActorErrors.filterExceptionMessage(ex.getMessage)) {
+          Logger.warn(s"[${this.getClass.getName}] FlowEventWarning Error processing record: ${ex.getMessage}")
+        } else {
+          val msg = s"[${this.getClass.getName}] FlowEventError Error processing record: ${ex.getMessage}"
+          Logger.error(msg)
+          throw new RuntimeException(msg, ex)
+        }
+      }
+    }
+  }
+}

--- a/app/io/flow/event/v2/actors/PollActorErrors.scala
+++ b/app/io/flow/event/v2/actors/PollActorErrors.scala
@@ -1,0 +1,8 @@
+package io.flow.event.v2.actors
+
+object PollActorErrors {
+  /** Checks whether the first line of an exception message matches a partman partitioning error, which is not critical. */
+  def filterExceptionMessage(message: String): Boolean = {
+    message.split("\\r?\\n").headOption.exists(_.matches(".*duplicate key value violates unique constraint.*_p\\d{4}_\\d{2}_\\d{2}_pkey.*"))
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -40,4 +40,4 @@ publishTo := {
     Some("Artifactory Realm" at s"$host/libs-release-local")
   }
 }
-version := "0.2.49"
+version := "0.2.50-SNAPSHOT"

--- a/test/io/flow/event/v2/Helpers.scala
+++ b/test/io/flow/event/v2/Helpers.scala
@@ -58,7 +58,7 @@ trait Helpers {
     // println(s"  --> consumeUntil for eventId[$eventId]")
     q.consume[T] { rec =>
       // println(s"  --> record eventId[${rec.eventId}]")
-      all.append(rec)
+      all ++ rec
     }
 
     Await.result(

--- a/test/io/flow/event/v2/MockQueueSpec.scala
+++ b/test/io/flow/event/v2/MockQueueSpec.scala
@@ -24,7 +24,7 @@ class MockQueueSpec extends PlaySpec with OneAppPerSuite with Helpers {
 
     val rec = new AtomicReference[Option[Record]](None)
     q.consume[TestEvent] { r =>
-      rec.set(Some(r))
+      rec.set(r.headOption)
     }
 
     val eventId = publishTestObject(producer, testObject)


### PR DESCRIPTION
The end goal of this change is to make the `EventConsumer` insert batch.

Therefore, this change set allows for passing in a `Seq[Record] => Unit` instead of a `Record => Unit`. `PollActor` is unchanged and `PollActorBatch` is introduced to be extended by hte `EventConsumer`.

----

**This change will break any service that was using `Queue.consume` or `KinesisConsumer` directly.** 

We can come up with an entirely different tree not to break anything but that will force us to maintain both versions in the future. 

Any existing code like:

```
val f: Record => Unit = { r =>
  doSomething(r)
}
```

Can simply be replaced by:

```
val newF: Record => Unit = { rs =>
  rs.foreach(r => doSomething(r))
}
```