### PR TITLE
upgrade play-json

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,6 +15,7 @@ lazy val root = project
     testOptions += Tests.Argument("-oF"),
     libraryDependencies ++= Seq(
       ws,
+      "com.typesafe.play" %% "play-json" % "2.6.6",
       "io.flow" %% "lib-play" % "0.4.5",
       "com.amazonaws" % "amazon-kinesis-client" % "1.8.5",
       "org.scalatestplus" %% "play" % "1.4.0" % "test",

--- a/test/io/flow/event/UtilSpec.scala
+++ b/test/io/flow/event/UtilSpec.scala
@@ -1,0 +1,19 @@
+package io.flow.event
+
+import org.scalatest.{FunSpec, Matchers}
+import play.api.libs.json.{JsString, Json}
+
+class UtilSpec extends FunSpec with Matchers {
+
+  it("should extract a string from a JsObject") {
+    val obj = Json.obj(
+      ("name" -> JsString("val"))
+    )
+    Util.parseString(obj, "name") shouldBe Some("val")
+  }
+
+  it("should handle a JsValue that isn't an object") {
+    Util.parseString(JsString("name"), "name") shouldBe None
+  }
+
+}


### PR DESCRIPTION
compiles & all tests pass.
I feel like I'm missing something here.  Beacon (same play-json lib) tests fail with this:

```
java.lang.NoSuchMethodError: play.api.libs.json.JsLookup$.$bslash$extension(Lplay/api/libs/json/JsLookupResult;Ljava/lang/String;)Lplay/api/libs/json/JsLookupResult;
	at io.flow.event.Util$.parseString(Util.scala:12)
	at io.flow.event.Util$.mustParseString(Util.scala:19)
	at io.flow.event.Record$.fromJsValue(Queue.scala:15)
```