### PR TITLE
remove aws access keys

### DIFF
--- a/app/io/flow/event/v2/AWSCreds.scala
+++ b/app/io/flow/event/v2/AWSCreds.scala
@@ -10,14 +10,13 @@ class AWSCreds @Inject() (config: Config) extends AWSCredentialsProviderChain(
 
   List(
 
-    // for EC2 role
-    Some(DefaultAWSCredentialsProviderChain.getInstance()),
-
-    // fallback to known working config
     for {
       accessKey <- config.optionalString("aws.access.key")
       secretKey <- config.optionalString("aws.secret.key")
-    } yield new AWSStaticCredentialsProvider(new BasicAWSCredentials(accessKey, secretKey))
+    } yield new AWSStaticCredentialsProvider(new BasicAWSCredentials(accessKey, secretKey)),
+
+    // EC2 role
+    Some(DefaultAWSCredentialsProviderChain.getInstance())
 
   ).flatten.asJava
 

--- a/app/io/flow/event/v2/AWSCreds.scala
+++ b/app/io/flow/event/v2/AWSCreds.scala
@@ -1,0 +1,24 @@
+package io.flow.event.v2
+
+import com.amazonaws.auth._
+import io.flow.play.util.Config
+import javax.inject.Inject
+
+import scala.collection.JavaConverters._
+
+class AWSCreds @Inject() (config: Config) extends AWSCredentialsProviderChain(
+
+  List(
+
+    // for EC2 role
+    Some(DefaultAWSCredentialsProviderChain.getInstance()),
+
+    // fallback to known working config
+    for {
+      accessKey <- config.optionalString("aws.access.key")
+      secretKey <- config.optionalString("aws.secret.key")
+    } yield new AWSStaticCredentialsProvider(new BasicAWSCredentials(accessKey, secretKey))
+
+  ).flatten.asJava
+
+)

--- a/app/io/flow/event/v2/KinesisConsumer.scala
+++ b/app/io/flow/event/v2/KinesisConsumer.scala
@@ -4,6 +4,7 @@ import java.net.InetAddress
 import java.util.UUID
 import java.util.concurrent.Executors
 
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
 import com.amazonaws.services.kinesis.clientlibrary.interfaces.v2.{IRecordProcessor, IRecordProcessorFactory}
 import com.amazonaws.services.kinesis.clientlibrary.lib.worker.{InitialPositionInStream, KinesisClientLibConfiguration, Worker}
 import com.amazonaws.services.kinesis.clientlibrary.types.{InitializationInput, ProcessRecordsInput, ShutdownInput}
@@ -40,7 +41,7 @@ case class KinesisConsumer (
       new KinesisClientLibConfiguration(
         config.appName,
         config.streamName,
-        config.awsCredentialsProvider,
+        DefaultAWSCredentialsProviderChain.getInstance(),
         workerId
       ).withTableName(config.dynamoTableName)
         .withInitialLeaseTableReadCapacity(dynamoCapacity)

--- a/app/io/flow/event/v2/KinesisConsumer.scala
+++ b/app/io/flow/event/v2/KinesisConsumer.scala
@@ -4,7 +4,6 @@ import java.net.InetAddress
 import java.util.UUID
 import java.util.concurrent.Executors
 
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
 import com.amazonaws.services.kinesis.clientlibrary.interfaces.v2.{IRecordProcessor, IRecordProcessorFactory}
 import com.amazonaws.services.kinesis.clientlibrary.lib.worker.{InitialPositionInStream, KinesisClientLibConfiguration, Worker}
 import com.amazonaws.services.kinesis.clientlibrary.types.{InitializationInput, ProcessRecordsInput, ShutdownInput}

--- a/app/io/flow/event/v2/KinesisConsumer.scala
+++ b/app/io/flow/event/v2/KinesisConsumer.scala
@@ -41,7 +41,7 @@ case class KinesisConsumer (
       new KinesisClientLibConfiguration(
         config.appName,
         config.streamName,
-        DefaultAWSCredentialsProviderChain.getInstance(),
+        config.awsCredentialsProvider,
         workerId
       ).withTableName(config.dynamoTableName)
         .withInitialLeaseTableReadCapacity(dynamoCapacity)

--- a/app/io/flow/event/v2/Queue.scala
+++ b/app/io/flow/event/v2/Queue.scala
@@ -48,10 +48,7 @@ trait Producer[T] {
 
 
 /**
-  * Builds our default producer/consumer. Requires the following config
-  * variables to be set:
-  *   - aws.access.key
-  *   - aws.secret.key
+  * Builds our default producer/consumer
   */
 class DefaultQueue @Inject() (
   config: Config
@@ -105,14 +102,8 @@ class DefaultQueue @Inject() (
     }
   }
 
-  private[this] def awsCredentials = new BasicAWSCredentials(
-    config.requiredString("aws.access.key"),
-    config.requiredString("aws.secret.key")
-  )
-
   private[this] def streamConfig[T: TypeTag] = {
     DefaultStreamConfig(
-      awsCredentials,
       appName = config.requiredString("name"),
       streamName = streamName[T]
     )

--- a/app/io/flow/event/v2/Queue.scala
+++ b/app/io/flow/event/v2/Queue.scala
@@ -51,7 +51,8 @@ trait Producer[T] {
   * Builds our default producer/consumer
   */
 class DefaultQueue @Inject() (
-  config: Config
+  config: Config,
+  creds: AWSCreds
 ) extends Queue with StreamUsage {
 
   import scala.collection.JavaConverters._
@@ -104,6 +105,7 @@ class DefaultQueue @Inject() (
 
   private[this] def streamConfig[T: TypeTag] = {
     DefaultStreamConfig(
+      creds,
       appName = config.requiredString("name"),
       streamName = streamName[T]
     )

--- a/app/io/flow/event/v2/StreamConfig.scala
+++ b/app/io/flow/event/v2/StreamConfig.scala
@@ -1,6 +1,7 @@
 package io.flow.event.v2
 
 import com.amazonaws.ClientConfiguration
+import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.services.kinesis.{AmazonKinesis, AmazonKinesisClientBuilder}
 import io.flow.event.Naming
 
@@ -9,6 +10,7 @@ trait StreamConfig {
   val streamName: String
   val maxRecords: Int
   val idleTimeBetweenReadsInMillis: Int
+  val awsCredentialsProvider: AWSCredentialsProvider
 
   def kinesisClient: AmazonKinesis
 
@@ -21,6 +23,7 @@ trait StreamConfig {
 }
 
 case class DefaultStreamConfig(
+  awsCredentialsProvider: AWSCreds,
   appName: String,
   streamName: String,
   maxRecords: Int = 1000,   // number of records in each fetch
@@ -29,6 +32,7 @@ case class DefaultStreamConfig(
 
   override def kinesisClient: AmazonKinesis = {
     AmazonKinesisClientBuilder.standard().
+      withCredentials(awsCredentialsProvider).
       withClientConfiguration(
         new ClientConfiguration()
           .withMaxErrorRetry(10)

--- a/app/io/flow/event/v2/StreamConfig.scala
+++ b/app/io/flow/event/v2/StreamConfig.scala
@@ -1,7 +1,6 @@
 package io.flow.event.v2
 
 import com.amazonaws.ClientConfiguration
-import com.amazonaws.auth.{AWSCredentials, AWSCredentialsProvider, AWSStaticCredentialsProvider}
 import com.amazonaws.services.kinesis.{AmazonKinesis, AmazonKinesisClientBuilder}
 import io.flow.event.Naming
 
@@ -10,7 +9,6 @@ trait StreamConfig {
   val streamName: String
   val maxRecords: Int
   val idleTimeBetweenReadsInMillis: Int
-  val awsCredentialsProvider: AWSCredentialsProvider
 
   def kinesisClient: AmazonKinesis
 
@@ -23,37 +21,11 @@ trait StreamConfig {
 }
 
 case class DefaultStreamConfig(
-  awsCredentials: AWSCredentials,
   appName: String,
   streamName: String,
   maxRecords: Int = 1000,   // number of records in each fetch
   idleTimeBetweenReadsInMillis: Int = 1000
 ) extends StreamConfig {
-
-  override lazy val awsCredentialsProvider: AWSCredentialsProvider = new AWSStaticCredentialsProvider(awsCredentials)
-
-  override def kinesisClient: AmazonKinesis = {
-    AmazonKinesisClientBuilder.standard().
-      withCredentials(awsCredentialsProvider).
-      withClientConfiguration(
-        new ClientConfiguration()
-          .withMaxErrorRetry(10)
-          .withMaxConsecutiveRetriesBeforeThrottling(1)
-          .withThrottledRetries(true)
-          .withConnectionTTL(600000)
-      ).
-      build()
-  }
-}
-
-case class NoCredentialsStreamConfig(
-  appName: String,
-  streamName: String,
-  maxRecords: Int = 1000,   // number of records in each fetch
-  idleTimeBetweenReadsInMillis: Int = 1000
-) extends StreamConfig {
-
-  override lazy val awsCredentialsProvider: AWSCredentialsProvider = sys.error("No credentials for NoCredentialsStreamConfig")
 
   override def kinesisClient: AmazonKinesis = {
     AmazonKinesisClientBuilder.standard().
@@ -66,5 +38,4 @@ case class NoCredentialsStreamConfig(
       ).
       build()
   }
-
 }

--- a/conf/test.conf
+++ b/conf/test.conf
@@ -1,2 +1,0 @@
-aws.access.key=${?CONF_AWS_ACCESS_KEY}
-aws.secret.key=${?CONF_AWS_SECRET_KEY}


### PR DESCRIPTION
We should be using ec2 instance roles. API requests from our EC2 instances will
work without having to manually set an API key