### PR TITLE
Upgrade libraries: io.flow, org.mockito

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,13 +14,13 @@ lazy val root = project
     libraryDependencies ++= Seq(
       ws,
       guice,
-      "io.flow" %% "lib-util" % "0.0.6",
-      "io.flow" %% "lib-play-play26" % "0.4.88",
+      "io.flow" %% "lib-util" % "0.0.9",
+      "io.flow" %% "lib-play-play26" % "0.4.90",
       "com.amazonaws" % "amazon-kinesis-client" % "1.9.1",
       // evict aws dependency on allegedly incompatible "jackson-dataformat-cbor" % "2.6.7",
       "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % "2.9.6",
-      "org.mockito" % "mockito-core" % "2.19.1" % Test,
-      "io.flow" %% "lib-test-utils" % "0.0.14" % Test
+      "org.mockito" % "mockito-core" % "2.20.1" % Test,
+      "io.flow" %% "lib-test-utils" % "0.0.18" % Test
     ),
     resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/",
     resolvers += "scalaz-bintray" at "https://dl.bintray.com/scalaz/releases",


### PR DESCRIPTION
- io.flow
  - lib-play-play26 (0.4.88 => 0.4.90)
  - lib-test-utils (0.0.14 => 0.0.18)
  - lib-util (0.0.6 => 0.0.9)

- org.mockito
  - mockito-core (2.19.1 => 2.20.1)
