### PR TITLE
Remove unused ExecutionContexts

### DIFF
--- a/app/io/flow/event/JsonUtil.scala
+++ b/app/io/flow/event/JsonUtil.scala
@@ -1,6 +1,6 @@
 package io.flow.event
 
-import io.flow.play.util.Booleans
+import io.flow.util.Booleans
 import play.api.Logger
 import play.api.libs.json._
 

--- a/app/io/flow/event/v2/KinesisConsumer.scala
+++ b/app/io/flow/event/v2/KinesisConsumer.scala
@@ -14,7 +14,6 @@ import org.joda.time.DateTime
 import play.api.Logger
 
 import scala.collection.JavaConverters._
-import scala.concurrent.ExecutionContext
 
 case class KinesisConsumer (
   config: StreamConfig,
@@ -60,7 +59,7 @@ case class KinesisConsumer (
 
   exec.execute(worker)
 
-  def shutdown(implicit ec: ExecutionContext): Unit = {
+  def shutdown(): Unit = {
     exec.shutdown()
   }
 

--- a/app/io/flow/event/v2/KinesisProducer.scala
+++ b/app/io/flow/event/v2/KinesisProducer.scala
@@ -6,13 +6,12 @@ import java.util
 import com.amazonaws.services.kinesis.model._
 import io.flow.event.Util
 import play.api.Logger
-import play.api.libs.json.{JsValue, Json, Writes}
+import play.api.libs.json.{Json, Writes}
 
 import scala.annotation.tailrec
-import scala.collection.mutable.ListBuffer
-import scala.concurrent.ExecutionContext
-import scala.util.{Failure, Random, Success, Try}
 import scala.collection.JavaConverters._
+import scala.collection.mutable.ListBuffer
+import scala.util.{Failure, Random, Success, Try}
 
 case class KinesisProducer[T](
   config: StreamConfig,
@@ -26,7 +25,7 @@ case class KinesisProducer[T](
 
   setup()
 
-  override def publish[U <: T](event: U)(implicit ec: ExecutionContext, serializer: Writes[U]): Unit =
+  override def publish[U <: T](event: U)(implicit serializer: Writes[U]): Unit =
     publishBatch(Seq(event))
 
   /**
@@ -36,7 +35,7 @@ case class KinesisProducer[T](
     * "Each PutRecords request can support up to 500 records. Each record in the request can be as large as 1 MB, up to
     * a limit of 5 MB for the entire request, including partition keys."
     */
-  override def publishBatch[U <: T](events: Seq[U])(implicit ec: ExecutionContext, serializer: Writes[U]): Unit = {
+  override def publishBatch[U <: T](events: Seq[U])(implicit serializer: Writes[U]): Unit = {
     // Make sure that there are events: AWS will complain otherwise
     if (events.nonEmpty) {
       val batchedRecords = new ListBuffer[util.List[PutRecordsRequestEntry]]()
@@ -113,7 +112,7 @@ case class KinesisProducer[T](
     kinesisClient.putRecords(putRecordsRequest)
   }
 
-  override def shutdown(implicit ec: ExecutionContext): Unit = {
+  override def shutdown(): Unit = {
     kinesisClient.shutdown()
   }
 

--- a/app/io/flow/event/v2/StreamUsage.scala
+++ b/app/io/flow/event/v2/StreamUsage.scala
@@ -2,7 +2,6 @@ package io.flow.event.v2
 
 import io.flow.event.Record
 import io.flow.util.StreamNames
-import play.api.Logger
 import play.api.libs.json.JsValue
 
 import scala.collection.concurrent

--- a/app/io/flow/event/v2/actors/PollActorBatch.scala
+++ b/app/io/flow/event/v2/actors/PollActorBatch.scala
@@ -48,10 +48,7 @@ trait PollActorBatch extends Actor with ActorLogging with ErrorHandler {
     }
   }
 
-  def start[T: TypeTag](
-    executionContextName: String,
-    pollTime: FiniteDuration = defaultDuration
-  ): Unit = {
+  def start[T: TypeTag](pollTime: FiniteDuration = defaultDuration): Unit = {
     Logger.info(s"[${getClass.getName}] Scheduling poll every $pollTime")
 
     queue.consume[T](

--- a/app/io/flow/event/v2/actors/PollActorBatch.scala
+++ b/app/io/flow/event/v2/actors/PollActorBatch.scala
@@ -6,12 +6,9 @@ import io.flow.event.v2.{MockQueue, Queue}
 import io.flow.play.actors.ErrorHandler
 import play.api.Logger
 
-import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.{FiniteDuration, MILLISECONDS, SECONDS}
 import scala.reflect.runtime.universe.TypeTag
 import scala.util.{Failure, Success, Try}
-
-
 
 /**
   * [[PollActorBatch]] periodically polls a kinesis stream invoking process once per message batch
@@ -44,8 +41,6 @@ trait PollActorBatch extends Actor with ActorLogging with ErrorHandler {
 
   def queue: Queue
 
-  private[this] implicit var ec: ExecutionContext = _
-
   private[this] def defaultDuration = {
     queue match {
       case _:  MockQueue => FiniteDuration(20, MILLISECONDS)
@@ -54,20 +49,10 @@ trait PollActorBatch extends Actor with ActorLogging with ErrorHandler {
   }
 
   def start[T: TypeTag](
-                         executionContextName: String,
-                         pollTime: FiniteDuration = defaultDuration
-                       ) {
-    val ec = system.dispatchers.lookup(executionContextName)
-    startWithExecutionContext(ec, pollTime)
-  }
-
-  def startWithExecutionContext[T: TypeTag](
-                                             executionContext: ExecutionContext,
-                                             pollTime: FiniteDuration = FiniteDuration(5, SECONDS)
-                                           ) {
+    executionContextName: String,
+    pollTime: FiniteDuration = defaultDuration
+  ): Unit = {
     Logger.info(s"[${getClass.getName}] Scheduling poll every $pollTime")
-
-    this.ec = executionContext
 
     queue.consume[T](
       pollTime = pollTime,

--- a/test/io/flow/event/v2/MockQueueSpec.scala
+++ b/test/io/flow/event/v2/MockQueueSpec.scala
@@ -13,8 +13,6 @@ import scala.concurrent.duration._
 
 class MockQueueSpec extends PlaySpec with GuiceOneAppPerSuite with Helpers {
 
-  import scala.concurrent.ExecutionContext.Implicits.global
-
   private[this] val testObject = TestObject(id = "1")
 
   "all" in {


### PR DESCRIPTION
This change removes the unnecessary `ExecutionContext` when consuming and publishing.

In particular, `PollActorBatch` does not require a context to start any more, in turn making all the `foo.consumer.context` obsolete.

**This is a breaking change.**