### PR TITLE
Disabling shard metrics

### DIFF
--- a/app/io/flow/event/StreamNames.scala
+++ b/app/io/flow/event/StreamNames.scala
@@ -1,6 +1,6 @@
 package io.flow.event
 
-import io.flow.util.FlowEnvironment
+import io.flow.play.util.FlowEnvironment
 
 import scala.reflect.runtime.universe._
 

--- a/app/io/flow/event/StreamNames.scala
+++ b/app/io/flow/event/StreamNames.scala
@@ -1,6 +1,5 @@
 package io.flow.event
 
-import io.flow.play.util.FlowEnvironment
 import io.flow.util.FlowEnvironment
 
 import scala.reflect.runtime.universe._

--- a/app/io/flow/event/StreamNames.scala
+++ b/app/io/flow/event/StreamNames.scala
@@ -1,6 +1,8 @@
 package io.flow.event
 
 import io.flow.play.util.FlowEnvironment
+import io.flow.util.FlowEnvironment
+
 import scala.reflect.runtime.universe._
 
 @deprecated("Deprecated in favour of lib-util (io.flow.util.*)", "0.3.45")

--- a/app/io/flow/event/v2/KinesisConsumer.scala
+++ b/app/io/flow/event/v2/KinesisConsumer.scala
@@ -49,7 +49,7 @@ case class KinesisConsumer (
         .withCleanupLeasesUponShardCompletion(true)
         .withIdleTimeBetweenReadsInMillis(config.idleTimeBetweenReadsInMillis.toLong)
         .withMaxRecords(config.maxRecords)
-        .withMetricsLevel(MetricsLevel.DETAILED)
+        .withMetricsLevel(MetricsLevel.NONE)
         .withFailoverTimeMillis(10000) // See https://github.com/awslabs/amazon-kinesis-connectors/issues/10
     ).kinesisClient(config.kinesisClient)
     .build()

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,6 @@ lazy val root = project
       guice,
       "io.flow" %% "lib-play-play26" % "0.5.33",
       "com.amazonaws" % "amazon-kinesis-client" % "1.9.3",
-      "com.amazonaws" % "aws-java-sdk-dynamodb" % "1.11.498",
       // evict aws dependency on allegedly incompatible "jackson-dataformat-cbor" % "2.6.7",
       "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % "2.9.8",
       "org.mockito" % "mockito-core" % "2.23.4" % Test,

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,3 @@
-import play.sbt.PlayScala._
 import sbt.Keys.scalacOptions
 
 name := "lib-event-play26"
@@ -17,6 +16,7 @@ lazy val root = project
       guice,
       "io.flow" %% "lib-play-play26" % "0.5.33",
       "com.amazonaws" % "amazon-kinesis-client" % "1.9.3",
+      "com.amazonaws" % "aws-java-sdk-dynamodb" % "1.11.498",
       // evict aws dependency on allegedly incompatible "jackson-dataformat-cbor" % "2.6.7",
       "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % "2.9.8",
       "org.mockito" % "mockito-core" % "2.23.4" % Test,


### PR DESCRIPTION
Should dramatically decrease the cost to run KCL in production with no impact on performance.