### PR TITLE
Increment failover time

### DIFF
--- a/app/io/flow/event/v2/KinesisConsumer.scala
+++ b/app/io/flow/event/v2/KinesisConsumer.scala
@@ -50,7 +50,7 @@ case class KinesisConsumer (
         .withIdleTimeBetweenReadsInMillis(config.idleTimeBetweenReadsInMillis.toLong)
         .withMaxRecords(config.maxRecords)
         .withMetricsLevel(MetricsLevel.NONE)
-        .withFailoverTimeMillis(10000) // See https://github.com/awslabs/amazon-kinesis-connectors/issues/10
+        .withFailoverTimeMillis(30000) // See https://github.com/awslabs/amazon-kinesis-connectors/issues/10
     ).kinesisClient(config.kinesisClient)
     .build()
 


### PR DESCRIPTION
Trying to alleviate 

```
com.amazonaws.services.kinesis.clientlibrary.exceptions.ShutdownException: Can't update checkpoint - instance doesn't hold the lease for this shard
```

**This is not a long term solution**
