### PR TITLE
 Log errors while checkpointing on Kinesis consumer shutdown

### DIFF
--- a/app/io/flow/event/v2/KinesisConsumer.scala
+++ b/app/io/flow/event/v2/KinesisConsumer.scala
@@ -150,7 +150,14 @@ case class KinesisRecordProcessor[T](
 
   override def shutdown(input: ShutdownInput): Unit = {
     logger_.withKeyValue("reason", input.getShutdownReason.toString).info("Shutting down")
-    input.getCheckpointer.checkpoint()
+    try {
+      input.getCheckpointer.checkpoint()
+    } catch {
+      case NonFatal(e) =>
+        logger_
+          .withKeyValue("reason", input.getShutdownReason.toString)
+          .error("[FlowKinesisError] Error while checkpointing when shutting down Kinesis consumer. Cannot checkpoint.", e)
+    }
   }
 
 }

--- a/app/io/flow/event/v2/KinesisConsumer.scala
+++ b/app/io/flow/event/v2/KinesisConsumer.scala
@@ -14,6 +14,7 @@ import io.flow.util.FlowEnvironment
 import org.joda.time.DateTime
 
 import scala.collection.JavaConverters._
+import scala.util.control.NonFatal
 
 case class KinesisConsumer (
   config: StreamConfig,

--- a/app/io/flow/event/v2/KinesisConsumer.scala
+++ b/app/io/flow/event/v2/KinesisConsumer.scala
@@ -153,6 +153,7 @@ case class KinesisRecordProcessor[T](
     try {
       input.getCheckpointer.checkpoint()
     } catch {
+      // for instance lease has expired
       case NonFatal(e) =>
         logger_
           .withKeyValue("reason", input.getShutdownReason.toString)


### PR DESCRIPTION
Should prevent shutdown from throwing exceptions and have the Kinesis having to handle them.