### PR TITLE
MockQueue: Move execution out of mock consumer and into single loop

### DIFF
--- a/app/io/flow/event/v2/MockQueue.scala
+++ b/app/io/flow/event/v2/MockQueue.scala
@@ -66,6 +66,7 @@ class MockQueue @Inject()(
   }
 
   override def shutdown(): Unit = {
+    // use shutdownNow in case the provided action comes with a while-sleep loop.
     ses.shutdownNow()
     shutdownConsumers()
     streams.clear()

--- a/test/io/flow/event/v2/MockQueueSpec.scala
+++ b/test/io/flow/event/v2/MockQueueSpec.scala
@@ -65,7 +65,7 @@ class MockQueueSpec extends PlaySpec with GuiceOneAppPerSuite with Helpers with 
     val producerContext = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(producersPoolSize))
     val consumerContext = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(consumersPoolSize))
 
-    val q = new MockQueue(logger)
+    val q = new MockQueue(logger)(1.nano)
     val producer = q.producer[TestEvent]()
 
     val count = new LongAdder()
@@ -73,7 +73,7 @@ class MockQueueSpec extends PlaySpec with GuiceOneAppPerSuite with Helpers with 
     // consume: start [[consumersSize]] consumers consuming concurrently
     (1 to consumersPoolSize).foreach { _ =>
       Future {
-        q.consume[TestEvent](_ => count.increment(), 1.nano)
+        q.consume[TestEvent](_ => count.increment())
       } (consumerContext)
     }
 


### PR DESCRIPTION
- Previously we would create one thread pool per stream we were consuming,
   checking on that stream every ~20 milliseconds
 - This change moves the thread pool out of the mock consumer and into the
   mock queue, with the mock queue iterating through all of its consumers
   directly
 - Hypothesis that this should be lighter on the JVM as we will minimize
   the number of threads, in particular for larger projects like payment
   that consume from a large number of streams (and thus should make
   our tests faster and more stable)