### PR TITLE
Remove metrics

### DIFF
--- a/app/io/flow/event/v2/Queue.scala
+++ b/app/io/flow/event/v2/Queue.scala
@@ -4,7 +4,6 @@ import java.util.concurrent.ConcurrentLinkedQueue
 
 import io.flow.event.Record
 import io.flow.log.RollbarLogger
-import io.flow.play.metrics.MetricsSystem
 import io.flow.play.util.Config
 import io.flow.util.StreamNames
 import javax.inject.Inject
@@ -66,7 +65,6 @@ trait Producer[T] {
 class DefaultQueue @Inject() (
   config: Config,
   creds: AWSCreds,
-  metrics: MetricsSystem,
   logger: RollbarLogger,
 ) extends Queue with StreamUsage {
 
@@ -99,7 +97,6 @@ class DefaultQueue @Inject() (
         streamConfig[T],
         creds,
         f,
-        metrics,
         logger,
       )
     )

--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,6 @@ lazy val root = project
       ws,
       guice,
       "io.flow" %% s"lib-play$libSuffix2" % "0.5.67",
-      "io.flow" %% s"lib-play-graphite$libSuffix2" % "0.0.99",
       "com.amazonaws" % "amazon-kinesis-client" % "1.9.3",
       // evict aws dependency on allegedly incompatible "jackson-dataformat-cbor" % "2.6.7",
       "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % "2.9.8",

--- a/conf/reference.conf
+++ b/conf/reference.conf
@@ -1,1 +1,0 @@
-play.modules.enabled += "io.flow.play.metrics.MetricsModule"

--- a/test/io/flow/event/v2/QueueSpec.scala
+++ b/test/io/flow/event/v2/QueueSpec.scala
@@ -4,7 +4,6 @@ import com.amazonaws.services.kinesis.clientlibrary.lib.worker.SimpleRecordsFetc
 import io.flow.lib.event.test.v0.models.TestEvent
 import io.flow.log.RollbarLogger
 import io.flow.play.clients.ConfigModule
-import io.flow.play.metrics.MockMetricsSystem
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import org.scalatestplus.play.PlaySpec
 import play.api.Application
@@ -27,7 +26,7 @@ class QueueSpec extends PlaySpec with GuiceOneAppPerSuite with Helpers {
       val creds = new AWSCreds(config)
       val rollbar = RollbarLogger.SimpleLogger
 
-      val queue = new DefaultQueue(config, creds, new MockMetricsSystem(), rollbar)
+      val queue = new DefaultQueue(config, creds, rollbar)
       val kclConfig = queue.streamConfig[TestEvent].toKclConfig(creds)
 
       kclConfig.getMaxRecords mustBe 1234


### PR DESCRIPTION
Removes the dependency to lib-play-graphite and its modules forcing each service to update their configuration.

