### PR TITLE
Remove old version of jackson-dataformat-cbor

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,8 +20,6 @@ lazy val root = project
       "io.flow" %% s"lib-play$libSuffix2" % "0.5.73",
       "io.flow" %% s"lib-play-graphite$libSuffix2" % "0.1.2",
       "com.amazonaws" % "amazon-kinesis-client" % "1.9.3",
-      // evict aws dependency on allegedly incompatible "jackson-dataformat-cbor" % "2.6.7",
-      "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % "2.9.8",
       "org.mockito" % "mockito-core" % "2.23.4" % Test,
       "io.flow" %% s"lib-test-utils$libSuffix1" % "0.0.58" % Test,
       compilerPlugin("com.github.ghik" %% "silencer-plugin" % "1.4.1"),


### PR DESCRIPTION
It seems like originally jackson-dataformat-cbor 2.8.11 was added to evict an older incompatible version, but now the AWS SDK depends on 2.9.8 so we don't need to explicitly specify this