### PR TITLE
migration to sbt 1.3.0 and introduction of coursier seem to have brok…

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,8 @@ organization := "io.flow"
 
 scalaVersion in ThisBuild := "2.12.10"
 
+ThisBuild / useCoursier := false
+
 lazy val root = project
   .in(file("."))
   .enablePlugins(PlayScala)


### PR DESCRIPTION
…en the tests. disabling coursier in build.sbt