### PR TITLE
Update Kinesis client configuration

### DIFF
--- a/app/io/flow/event/v2/KinesisProducer.scala
+++ b/app/io/flow/event/v2/KinesisProducer.scala
@@ -6,6 +6,7 @@ import java.util
 import com.amazonaws.services.kinesis.model._
 import com.github.ghik.silencer.silent
 import io.flow.log.RollbarLogger
+import org.apache.http.NoHttpResponseException
 import play.api.libs.json.{Json, Writes}
 
 import scala.annotation.tailrec
@@ -108,7 +109,7 @@ case class KinesisProducer[T](
           }
         }
 
-      case Failure(ex @ (_ : ProvisionedThroughputExceededException | _ : KMSThrottlingException)) if attempts <= MaxRetries =>
+      case Failure(ex @ (_ : ProvisionedThroughputExceededException | _ : KMSThrottlingException | _ : NoHttpResponseException)) if attempts <= MaxRetries =>
         logger_.info(s"[FlowKinesisWarn] Exception thrown when publishing batch. Retrying $attempts/$MaxRetries ...", ex)
         waitBeforeRetry()
         publishBatchRetries(entries, attempts + 1)

--- a/app/io/flow/event/v2/KinesisProducer.scala
+++ b/app/io/flow/event/v2/KinesisProducer.scala
@@ -116,7 +116,7 @@ case class KinesisProducer[T](
       // specific case to catch
       //   com.amazonaws.SdkClientException: Unable to execute HTTP request: The target server failed to respond
       //   Caused by: org.apache.http.NoHttpResponseException: The target server failed to respond
-      case Failure(ex @ (_ : SdkClientException)) if ex.getCause.isInstanceOf[NoHttpResponseException] && attempts <= MaxRetries =>
+      case Failure(ex @ (_ : SdkClientException)) if Option(ex.getCause).exists(_.isInstanceOf[NoHttpResponseException]) && attempts <= MaxRetries =>
         attemptRetry(attempts, entries, ex)
 
       case Failure(ex) => throw ex

--- a/app/io/flow/event/v2/KinesisProducer.scala
+++ b/app/io/flow/event/v2/KinesisProducer.scala
@@ -3,6 +3,7 @@ package io.flow.event.v2
 import java.nio.ByteBuffer
 import java.util
 
+import com.amazonaws.SdkClientException
 import com.amazonaws.services.kinesis.model._
 import com.github.ghik.silencer.silent
 import io.flow.log.RollbarLogger
@@ -109,10 +110,14 @@ case class KinesisProducer[T](
           }
         }
 
-      case Failure(ex @ (_ : ProvisionedThroughputExceededException | _ : KMSThrottlingException | _ : NoHttpResponseException)) if attempts <= MaxRetries =>
-        logger_.info(s"[FlowKinesisWarn] Exception thrown when publishing batch. Retrying $attempts/$MaxRetries ...", ex)
-        waitBeforeRetry()
-        publishBatchRetries(entries, attempts + 1)
+      case Failure(ex @ (_ : ProvisionedThroughputExceededException | _ : KMSThrottlingException)) if attempts <= MaxRetries =>
+        attemptRetry(attempts, entries, ex)
+
+      // specific case to catch
+      //   com.amazonaws.SdkClientException: Unable to execute HTTP request: The target server failed to respond
+      //   Caused by: org.apache.http.NoHttpResponseException: The target server failed to respond
+      case Failure(ex @ (_ : SdkClientException)) if ex.getCause.isInstanceOf[NoHttpResponseException] && attempts <= MaxRetries =>
+        attemptRetry(attempts, entries, ex)
 
       case Failure(ex) => throw ex
     }
@@ -120,6 +125,16 @@ case class KinesisProducer[T](
 
   // uniform 1s to 5s
   private def waitBeforeRetry(): Unit = Thread.sleep(1000L + Random.nextInt(4000).toLong)
+
+  private def attemptRetry(
+    attempts: Int,
+    entries: util.List[PutRecordsRequestEntry],
+    ex: Throwable
+  ): Unit = {
+    logger_.info(s"[FlowKinesisWarn] Exception thrown when publishing batch. Retrying $attempts/$MaxRetries ...", ex)
+    waitBeforeRetry()
+    publishBatchRetries(entries, attempts + 1)
+  }
 
   private def doPublishBatch(entries: util.List[PutRecordsRequestEntry]): PutRecordsResult = {
     val putRecordsRequest = new PutRecordsRequest().withStreamName(config.streamName).withRecords(entries)

--- a/app/io/flow/event/v2/StreamConfig.scala
+++ b/app/io/flow/event/v2/StreamConfig.scala
@@ -99,6 +99,7 @@ case class DefaultStreamConfig(
           .withMaxConsecutiveRetriesBeforeThrottling(1)
           .withThrottledRetries(true)
           .withConnectionTTL(600000)
+          .withValidateAfterInactivityMillis(-1)
       )
 
     endpoints.kinesis.foreach { ep =>

--- a/app/io/flow/event/v2/StreamConfig.scala
+++ b/app/io/flow/event/v2/StreamConfig.scala
@@ -99,7 +99,6 @@ case class DefaultStreamConfig(
           .withMaxConsecutiveRetriesBeforeThrottling(1)
           .withThrottledRetries(true)
           .withConnectionTTL(600000)
-          .withConnectionMaxIdleMillis(30000)
       )
 
     endpoints.kinesis.foreach { ep =>

--- a/app/io/flow/event/v2/StreamConfig.scala
+++ b/app/io/flow/event/v2/StreamConfig.scala
@@ -99,7 +99,7 @@ case class DefaultStreamConfig(
           .withMaxConsecutiveRetriesBeforeThrottling(1)
           .withThrottledRetries(true)
           .withConnectionTTL(600000)
-          .withValidateAfterInactivityMillis(-1)
+          .withConnectionMaxIdleMillis(30000)
       )
 
     endpoints.kinesis.foreach { ep =>


### PR DESCRIPTION
Attempt to resolve the following AWS Kinesis connection error:
```
com.amazonaws.SdkClientException: Unable to execute HTTP request: The target server failed to respond
...
...
Caused by: org.apache.http.NoHttpResponseException: The target server failed to respond
```

We receive 300+/week:
https://service.us2.sumologic.com/ui/#/search/0A9CYFcX5LWdND3PyCjfzkpTgJRdbdNHsmjZiIgV

Set kinesis client configuration so that we do not `ValidateAfterInactivityMillis` to prevent `NoHttpResponseException` - see `withValidateAfterInactivityMillis`:
http://fireduck.com/java/aws/index.html?com/amazonaws/ClientConfiguration.html