### PR TITLE
Add Dynamo DB Streaming consumer and queue

### DIFF
--- a/app/io/flow/event/Bindings.scala
+++ b/app/io/flow/event/Bindings.scala
@@ -7,10 +7,12 @@ class QueueModule extends Module {
   def bindings(env: Environment, conf: Configuration) = {
     env.mode match {
       case Mode.Prod | Mode.Dev => Seq(
-        bind[v2.Queue].to[v2.DefaultQueue]
+        bind[v2.Queue].to[v2.DefaultQueue],
+        bind[v2.DynamoStreamQueue].to[v2.DefaultDynamoStreamQueue]
       )
       case Mode.Test => Seq(
-        bind[v2.Queue].to[v2.MockQueue]
+        bind[v2.Queue].to[v2.MockQueue],
+        bind[v2.DynamoStreamQueue].to[v2.MockDynamoStreamQueue]
       )
     }
   }

--- a/app/io/flow/event/DynamoStreamRecord.scala
+++ b/app/io/flow/event/DynamoStreamRecord.scala
@@ -4,7 +4,6 @@ import com.amazonaws.services.dynamodbv2.model.AttributeValue
 import org.joda.time.DateTime
 import play.api.libs.json.{JsNull, JsValue}
 
-import scala.jdk.CollectionConverters._
 import scala.reflect.runtime.universe._
 
 object DynamoStreamRecord {
@@ -15,8 +14,8 @@ object DynamoStreamRecord {
     recordType = recordType,
     js = JsNull,
     eventName = DynamoStreamEventName(record.getEventName),
-    newImage = Option(record.getDynamodb.getNewImage).map(_.asScala.toMap).getOrElse(Map.empty),
-    oldImage = Option(record.getDynamodb.getOldImage).map(_.asScala.toMap).getOrElse(Map.empty)
+    newImage = Option(record.getDynamodb.getNewImage),
+    oldImage = Option(record.getDynamodb.getOldImage)
   )
 }
 
@@ -27,8 +26,8 @@ class DynamoStreamRecord(
   override val js: JsValue,
   val recordType: Type,
   val eventName: DynamoStreamEventName,
-  val newImage: Map[String, AttributeValue],
-  val oldImage: Map[String, AttributeValue]
+  val newImage: Option[java.util.Map[String, AttributeValue]],
+  val oldImage: Option[java.util.Map[String, AttributeValue]]
 ) extends Record(eventId, timestamp, arrivalTimestamp, js) {
   override lazy val discriminator: Option[String] = Some(recordType.typeSymbol.name.toString)
 }

--- a/app/io/flow/event/DynamoStreamRecord.scala
+++ b/app/io/flow/event/DynamoStreamRecord.scala
@@ -1,7 +1,6 @@
-package io.flow.event.v2
+package io.flow.event
 
 import com.amazonaws.services.dynamodbv2.model.AttributeValue
-import io.flow.event.Record
 import org.joda.time.DateTime
 import play.api.libs.json.{JsNull, JsValue}
 

--- a/app/io/flow/event/v2/AWSConfig.scala
+++ b/app/io/flow/event/v2/AWSConfig.scala
@@ -40,6 +40,16 @@ class AWSEndpoints @Inject() (environment: Environment) {
     case _ => None
   }
 
+  val dynamodbStreams = environment.mode match {
+    case Mode.Test => Some("http://localhost:4570") // localstack
+    case _ => None
+  }
+
+  val cloudWatch = environment.mode match {
+    case Mode.Test => Some("http://localhost:4582") // localstack
+    case _ => None
+  }
+
   environment.mode match {
     case Mode.Test =>
       // CBOR is a replacement for JSON. It is not yet supported by localstack

--- a/app/io/flow/event/v2/DynamoStreamConsumer.scala
+++ b/app/io/flow/event/v2/DynamoStreamConsumer.scala
@@ -1,0 +1,88 @@
+package io.flow.event.v2
+
+import com.amazonaws.auth.AWSCredentialsProviderChain
+import com.amazonaws.services.cloudwatch.AmazonCloudWatchClientBuilder
+import com.amazonaws.services.dynamodbv2.streamsadapter.StreamsWorkerFactory
+import com.amazonaws.services.dynamodbv2.streamsadapter.model.RecordAdapter
+import com.amazonaws.services.kinesis.clientlibrary.interfaces.v2.{IRecordProcessor, IRecordProcessorFactory}
+import com.amazonaws.services.kinesis.clientlibrary.types.ProcessRecordsInput
+import io.flow.event.Record
+import io.flow.log.RollbarLogger
+import io.flow.play.metrics.MetricsSystem
+
+import scala.jdk.CollectionConverters._
+
+case class DynamoStreamConsumer(
+  config: DynamoStreamConfig,
+  creds: AWSCredentialsProviderChain,
+  f: Seq[Record] => Unit,
+  metrics: MetricsSystem,
+  logger: RollbarLogger
+) extends KinesisConsumer(
+  config = config,
+  logger = logger,
+  worker = StreamsWorkerFactory.createDynamoDbStreamsWorker(
+    new DynamoStreamRecordProcessorFactory(
+      config = config,
+      f = f,
+      metrics= metrics,
+      logger = logger
+    ),
+    config.toKclConfig(creds),
+    config.kinesisClient,
+    config.dynamoDBClient,
+    AmazonCloudWatchClientBuilder.defaultClient()
+  )
+)
+
+class DynamoStreamRecordProcessorFactory(
+  config: StreamConfig,
+  f: Seq[Record] => Unit,
+  metrics: MetricsSystem,
+  logger: RollbarLogger
+) extends IRecordProcessorFactory {
+
+  override def createProcessor(): IRecordProcessor = new DynamoStreamRecordProcessor(
+    config = config,
+    f = f,
+    metrics = metrics,
+    logger = logger
+  )
+}
+
+class DynamoStreamRecordProcessor(
+  config: StreamConfig,
+  f: Seq[Record] => Unit,
+  metrics: MetricsSystem,
+  logger: RollbarLogger
+) extends KinesisRecordProcessor(config, f, metrics, logger) {
+
+  private val recordType = config.eventClass
+
+  override def processRecords(input: ProcessRecordsInput): Unit = {
+    logger_.withKeyValue("count", input.getRecords.size).info("Processing records")
+
+    streamLagMetric.update(input.getMillisBehindLatest)
+    numRecordsMetric.update(input.getRecords.size)
+
+    val kinesisRecords = input.getRecords.asScala.toSeq
+    val sequenceNumbers = kinesisRecords.map(_.getSequenceNumber)
+    if (kinesisRecords.nonEmpty) {
+      val flowRecords = kinesisRecords.flatMap { record =>
+        record match {
+          case adapter: RecordAdapter =>
+            Option(adapter.getInternalObject).map(DynamoStreamRecord.apply(recordType, _))
+          case _ =>
+            logger_.withKeyValue("record_type", record.getClass.getName).warn("Unknown record type")
+            None
+        }
+      }
+      executeRetry(flowRecords, sequenceNumbers)
+    }
+
+    kinesisRecords.lastOption.foreach { record =>
+      logger_.withKeyValue("checkpoint", record.getSequenceNumber).info("Checkpoint")
+      handleCheckpoint(input.getCheckpointer)
+    }
+  }
+}

--- a/app/io/flow/event/v2/DynamoStreamConsumer.scala
+++ b/app/io/flow/event/v2/DynamoStreamConsumer.scala
@@ -6,7 +6,7 @@ import com.amazonaws.services.dynamodbv2.streamsadapter.StreamsWorkerFactory
 import com.amazonaws.services.dynamodbv2.streamsadapter.model.RecordAdapter
 import com.amazonaws.services.kinesis.clientlibrary.interfaces.v2.{IRecordProcessor, IRecordProcessorFactory}
 import com.amazonaws.services.kinesis.clientlibrary.types.ProcessRecordsInput
-import io.flow.event.Record
+import io.flow.event.{DynamoStreamRecord, Record}
 import io.flow.log.RollbarLogger
 import io.flow.play.metrics.MetricsSystem
 

--- a/app/io/flow/event/v2/DynamoStreamConsumer.scala
+++ b/app/io/flow/event/v2/DynamoStreamConsumer.scala
@@ -1,7 +1,6 @@
 package io.flow.event.v2
 
 import com.amazonaws.auth.AWSCredentialsProviderChain
-import com.amazonaws.services.cloudwatch.AmazonCloudWatchClientBuilder
 import com.amazonaws.services.dynamodbv2.streamsadapter.StreamsWorkerFactory
 import com.amazonaws.services.dynamodbv2.streamsadapter.model.RecordAdapter
 import com.amazonaws.services.kinesis.clientlibrary.interfaces.v2.{IRecordProcessor, IRecordProcessorFactory}
@@ -31,7 +30,7 @@ case class DynamoStreamConsumer(
     config.toKclConfig(creds),
     config.kinesisClient,
     config.dynamoDBClient,
-    AmazonCloudWatchClientBuilder.defaultClient()
+    config.cloudWatchClient
   )
 )
 

--- a/app/io/flow/event/v2/DynamoStreamQueue.scala
+++ b/app/io/flow/event/v2/DynamoStreamQueue.scala
@@ -60,7 +60,7 @@ class DefaultDynamoStreamQueue @Inject() (
   override def shutdown(): Unit = shutdownConsumers()
 
   private[v2] def streamConfig[T: TypeTag] = {
-    val tableName = s"${FlowEnvironment.Current}.${typeName[T]}s"
+    val tn = tableName[T]
 
     //fixme move
     val dynamoDBClientBuilder = AmazonDynamoDBClientBuilder.standard()
@@ -69,23 +69,24 @@ class DefaultDynamoStreamQueue @Inject() (
     }
     val dynamoDBClient = dynamoDBClientBuilder.build()
 
-    val streamName = dynamoDBClient.describeTable(tableName).getTable.getLatestStreamArn
+    val streamName = dynamoDBClient.describeTable(tn).getTable.getLatestStreamArn
 
     DynamoStreamConfig(
       appName = appName,
       streamName = streamName,
-      dynamoTableName = tableName,
+      dynamoTableName = tn,
       eventClass = typeOf[T],
-      maxRecords = config.optionalInt(s"$tableName.maxRecords"),
-      idleMillisBetweenCalls = config.optionalLong(s"$tableName.idleMillisBetweenCalls"),
-      idleTimeBetweenReadsInMillis = config.optionalLong(s"$tableName.idleTimeBetweenReadsMs"),
-      maxLeasesForWorker = config.optionalInt(s"$tableName.maxLeasesForWorker"),
-      maxLeasesToStealAtOneTime = config.optionalInt(s"$tableName.maxLeasesToStealAtOneTime"),
+      maxRecords = config.optionalInt(s"$tn.maxRecords"),
+      idleMillisBetweenCalls = config.optionalLong(s"$tn.idleMillisBetweenCalls"),
+      idleTimeBetweenReadsInMillis = config.optionalLong(s"$tn.idleTimeBetweenReadsMs"),
+      maxLeasesForWorker = config.optionalInt(s"$tn.maxLeasesForWorker"),
+      maxLeasesToStealAtOneTime = config.optionalInt(s"$tn.maxLeasesToStealAtOneTime"),
       endpoints = endpoints,
       dynamoDBClient = dynamoDBClient
     )
   }
 
+  private[v2] def tableName[T: TypeTag] = s"${FlowEnvironment.Current}.${typeName[T]}s"
   private def typeName[T: TypeTag] = typeOf[T].typeSymbol.name.toString.toLowerCase
 }
 

--- a/app/io/flow/event/v2/DynamoStreamQueue.scala
+++ b/app/io/flow/event/v2/DynamoStreamQueue.scala
@@ -83,7 +83,7 @@ class DefaultDynamoStreamQueue @Inject() (
     )
   }
 
-  private[v2] def tableName[T: TypeTag] = s"${FlowEnvironment.Current}.${typeName[T]}s"
+  private def tableName[T: TypeTag] = s"${FlowEnvironment.Current}.${typeName[T]}s"
   private def typeName[T: TypeTag] = typeOf[T].typeSymbol.name.toString.toLowerCase
 }
 

--- a/app/io/flow/event/v2/DynamoStreamQueue.scala
+++ b/app/io/flow/event/v2/DynamoStreamQueue.scala
@@ -2,8 +2,6 @@ package io.flow.event.v2
 
 import java.util.concurrent.ConcurrentLinkedQueue
 
-import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder
 import io.flow.event.Record
 import io.flow.log.RollbarLogger
 import io.flow.play.metrics.MetricsSystem
@@ -61,14 +59,6 @@ class DefaultDynamoStreamQueue @Inject() (
 
   private[v2] def streamConfig[T: TypeTag] = {
     val tn = tableName[T]
-
-    //fixme move
-    val dynamoDBClientBuilder = AmazonDynamoDBClientBuilder.standard()
-    endpoints.dynamodb.foreach {
-      ep => dynamoDBClientBuilder.withEndpointConfiguration(new EndpointConfiguration(ep, endpoints.region))
-    }
-    val dynamoDBClient = dynamoDBClientBuilder.build()
-
     DynamoStreamConfig(
       appName = appName,
       dynamoTableName = tn,
@@ -78,8 +68,7 @@ class DefaultDynamoStreamQueue @Inject() (
       idleTimeBetweenReadsInMillis = config.optionalLong(s"$tn.idleTimeBetweenReadsMs"),
       maxLeasesForWorker = config.optionalInt(s"$tn.maxLeasesForWorker"),
       maxLeasesToStealAtOneTime = config.optionalInt(s"$tn.maxLeasesToStealAtOneTime"),
-      endpoints = endpoints,
-      dynamoDBClient = dynamoDBClient
+      endpoints = endpoints
     )
   }
 

--- a/app/io/flow/event/v2/DynamoStreamQueue.scala
+++ b/app/io/flow/event/v2/DynamoStreamQueue.scala
@@ -69,11 +69,8 @@ class DefaultDynamoStreamQueue @Inject() (
     }
     val dynamoDBClient = dynamoDBClientBuilder.build()
 
-    val streamName = dynamoDBClient.describeTable(tn).getTable.getLatestStreamArn
-
     DynamoStreamConfig(
       appName = appName,
-      streamName = streamName,
       dynamoTableName = tn,
       eventClass = typeOf[T],
       maxRecords = config.optionalInt(s"$tn.maxRecords"),

--- a/app/io/flow/event/v2/DynamoStreamQueue.scala
+++ b/app/io/flow/event/v2/DynamoStreamQueue.scala
@@ -1,0 +1,88 @@
+package io.flow.event.v2
+
+import java.util.concurrent.ConcurrentLinkedQueue
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder
+import com.amazonaws.services.dynamodbv2.document.DynamoDB
+import io.flow.event.Record
+import io.flow.log.RollbarLogger
+import io.flow.play.metrics.MetricsSystem
+import io.flow.play.util.Config
+import io.flow.util.FlowEnvironment
+import javax.inject.{Inject, Singleton}
+
+import scala.concurrent.duration._
+import scala.reflect.runtime.universe._
+
+trait DynamoStreamQueue extends Queue
+
+class DefaultDynamoStreamQueue @Inject() (
+  config: Config,
+  creds: AWSCreds,
+  endpoints: AWSEndpoints,
+  metrics: MetricsSystem,
+  logger: RollbarLogger
+) extends Queue with StreamUsage with DynamoStreamQueue {
+
+  import scala.jdk.CollectionConverters._
+
+  private[this] val consumers = new ConcurrentLinkedQueue[DynamoStreamConsumer]()
+
+  override def appName: String = config.requiredString("name")
+
+  override def producer[T: TypeTag](numberShards: Int = 0): Producer[T] = sys.error("Not supported for Dynamo DB streams")
+
+  override def consume[T: TypeTag](
+    f: Seq[Record] => Unit,
+    pollTime: FiniteDuration = 5.seconds
+  ): Unit = {
+    markConsumesStream(streamName[T], typeOf[T])
+    consumers.add(
+      DynamoStreamConsumer(
+        streamConfig[T],
+        creds,
+        f,
+        metrics,
+        logger,
+      )
+    )
+    ()
+  }
+
+  override def shutdownConsumers(): Unit = {
+    // synchronized to avoid a consumer being registered "in between" shutdown and clear
+    synchronized {
+      consumers.asScala.foreach(_.shutdown())
+      consumers.clear()
+    }
+  }
+
+  override def shutdown(): Unit = shutdownConsumers()
+
+  private def streamConfig[T: TypeTag] = {
+    val appName = config.requiredString("name")
+    val tableName = s"${FlowEnvironment.Current}.${typeName[T]}s"
+    val dynamoDBClient = AmazonDynamoDBClientBuilder.defaultClient()
+    val dynamoDb = new DynamoDB(dynamoDBClient)
+    val table = dynamoDb.getTable(tableName)
+    val streamName = Option(table.getDescription).getOrElse(table.describe()).getLatestStreamArn
+    DynamoStreamConfig(
+      appName = appName,
+      streamName = streamName,
+      dynamoTableName = tableName,
+      eventClass = typeOf[T],
+      maxRecords = config.optionalInt(s"$tableName.maxRecords"),
+      idleMillisBetweenCalls = config.optionalLong(s"$tableName.idleMillisBetweenCalls"),
+      idleTimeBetweenReadsInMillis = config.optionalLong(s"$tableName.idleTimeBetweenReadsMs"),
+      maxLeasesForWorker = config.optionalInt(s"$tableName.maxLeasesForWorker"),
+      maxLeasesToStealAtOneTime = config.optionalInt(s"$tableName.maxLeasesToStealAtOneTime"),
+      endpoints = endpoints,
+      dynamoDBClient = dynamoDBClient
+    )
+  }
+
+  private def typeName[T: TypeTag] = typeOf[T].typeSymbol.name.toString.toLowerCase
+}
+
+@Singleton
+class MockDynamoStreamQueue @Inject()(logger: RollbarLogger) extends MockQueue(logger) with DynamoStreamQueue

--- a/app/io/flow/event/v2/DynamoStreamRecord.scala
+++ b/app/io/flow/event/v2/DynamoStreamRecord.scala
@@ -1,0 +1,51 @@
+package io.flow.event.v2
+
+import com.amazonaws.services.dynamodbv2.model.AttributeValue
+import io.flow.event.Record
+import org.joda.time.DateTime
+import play.api.libs.json.{JsNull, JsValue}
+
+import scala.jdk.CollectionConverters._
+import scala.reflect.runtime.universe._
+
+object DynamoStreamRecord {
+  def apply(recordType: Type, record: com.amazonaws.services.dynamodbv2.model.Record) = new DynamoStreamRecord(
+    eventId = record.getEventID,
+    timestamp = DateTime.now,
+    arrivalTimestamp = new DateTime(record.getDynamodb.getApproximateCreationDateTime),
+    recordType = recordType,
+    js = JsNull,
+    eventName = DynamoStreamEventName(record.getEventName),
+    newImage = Option(record.getDynamodb.getNewImage).map(_.asScala.toMap).getOrElse(Map.empty),
+    oldImage = Option(record.getDynamodb.getOldImage).map(_.asScala.toMap).getOrElse(Map.empty)
+  )
+}
+
+class DynamoStreamRecord(
+  override val eventId: String,
+  override val timestamp: DateTime,
+  override val arrivalTimestamp: DateTime,
+  override val js: JsValue,
+  val recordType: Type,
+  val eventName: DynamoStreamEventName,
+  val newImage: Map[String, AttributeValue],
+  val oldImage: Map[String, AttributeValue]
+) extends Record(eventId, timestamp, arrivalTimestamp, js) {
+  override lazy val discriminator: Option[String] = Some(recordType.typeSymbol.name.toString)
+}
+
+sealed trait DynamoStreamEventName
+object DynamoStreamEventName {
+  case object Insert extends DynamoStreamEventName { override def toString = "INSERT" }
+  case object Modify extends DynamoStreamEventName { override def toString = "MODIFY" }
+  case object Remove extends DynamoStreamEventName { override def toString = "REMOVE" }
+  final case class UNDEFINED(override val toString: String) extends DynamoStreamEventName
+
+  val all = scala.List(Insert, Modify, Remove)
+  private[this] val byName = all.map(x => x.toString.toLowerCase -> x).toMap
+
+  def apply(value: String): DynamoStreamEventName = fromString(value).getOrElse(UNDEFINED(value))
+  def fromString(value: String): Option[DynamoStreamEventName] = byName.get(value.toLowerCase)
+}
+
+

--- a/app/io/flow/event/v2/StreamConfig.scala
+++ b/app/io/flow/event/v2/StreamConfig.scala
@@ -114,7 +114,6 @@ case class DefaultStreamConfig(
 
 case class DynamoStreamConfig(
   override val appName: String,
-  override val streamName: String,
   override val dynamoTableName: String,
   override val maxRecords: Option[Int],
   override val idleMillisBetweenCalls: Option[Long],
@@ -125,6 +124,8 @@ case class DynamoStreamConfig(
   override val endpoints: AWSEndpoints,
   dynamoDBClient: AmazonDynamoDB
 ) extends StreamConfig {
+
+  override def streamName: String = dynamoDBClient.describeTable(dynamoTableName).getTable.getLatestStreamArn
 
   override def toKclConfig(creds: AWSCredentialsProviderChain): KinesisClientLibConfiguration = {
     val dynamoCapacity = {

--- a/app/io/flow/event/v2/StreamConfig.scala
+++ b/app/io/flow/event/v2/StreamConfig.scala
@@ -6,6 +6,7 @@ import java.util.UUID
 import com.amazonaws.ClientConfiguration
 import com.amazonaws.auth.AWSCredentialsProviderChain
 import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
+import com.amazonaws.services.cloudwatch.{AmazonCloudWatch, AmazonCloudWatchClientBuilder}
 import com.amazonaws.services.dynamodbv2.streamsadapter.AmazonDynamoDBStreamsAdapterClient
 import com.amazonaws.services.dynamodbv2.{AmazonDynamoDB, AmazonDynamoDBStreamsClientBuilder}
 import com.amazonaws.services.kinesis.clientlibrary.lib.worker.{InitialPositionInStream, KinesisClientLibConfiguration}
@@ -152,10 +153,19 @@ case class DynamoStreamConfig(
   }
 
   override def kinesisClient: AmazonDynamoDBStreamsAdapterClient = {
-    val dynamoDBStreamsClient = AmazonDynamoDBStreamsClientBuilder.defaultClient()
-    val adapterClient = new AmazonDynamoDBStreamsAdapterClient(dynamoDBStreamsClient)
-    endpoints.kinesis.foreach(adapterClient.setEndpoint)
-    adapterClient
+    val builder = AmazonDynamoDBStreamsClientBuilder.standard()
+    endpoints.dynamodbStreams.foreach { ep =>
+      builder.withEndpointConfiguration(new EndpointConfiguration(ep, endpoints.region))
+    }
+    new AmazonDynamoDBStreamsAdapterClient(builder.build)
+  }
+
+  def cloudWatchClient: AmazonCloudWatch = {
+    val builder = AmazonCloudWatchClientBuilder.standard()
+    endpoints.cloudWatch.foreach { ep =>
+      builder.withEndpointConfiguration(new EndpointConfiguration(ep, endpoints.region))
+    }
+    builder.build()
   }
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -18,6 +18,7 @@ lazy val root = project
       "io.flow" %% "lib-akka-akka26" % "0.1.18",
       "io.flow" %% "lib-play-graphite-play28" % "0.1.45",
       "com.amazonaws" % "amazon-kinesis-client" % "1.13.3",
+      "com.amazonaws" % "dynamodb-streams-kinesis-adapter" % "1.5.1",
       // evict aws dependency on allegedly incompatible "jackson-dataformat-cbor" % "2.6.7",
       "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % "2.10.3",
       "org.mockito" % "mockito-core" % "3.3.3" % Test,

--- a/test/io/flow/event/v2/DynamoStreamHelpers.scala
+++ b/test/io/flow/event/v2/DynamoStreamHelpers.scala
@@ -1,0 +1,114 @@
+package io.flow.event.v2
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder
+import com.amazonaws.services.dynamodbv2.model._
+import io.flow.event.Record
+import io.flow.lib.event.test.v0.models.json._
+import io.flow.lib.event.test.v0.models.{TestObject, TestObjectUpserted}
+import io.flow.log.RollbarLogger
+import io.flow.play.clients.MockConfig
+import io.flow.play.metrics.MockMetricsSystem
+import play.api.Application
+
+import scala.concurrent.duration._
+import scala.concurrent.{Await, Future}
+import scala.reflect.runtime.universe._
+
+trait DynamoStreamHelpers {
+
+  import scala.concurrent.ExecutionContext.Implicits.global
+  import scala.jdk.CollectionConverters._
+
+  private def config(implicit app: Application) = app.injector.instanceOf[MockConfig]
+  private val publishCount = new AtomicInteger()
+
+  //fixme setup in config
+  lazy val dynamoDBClient = {
+    AmazonDynamoDBClientBuilder
+      .standard()
+      .withEndpointConfiguration(new EndpointConfiguration("http://localhost:4569", "us-east-1"))
+      .build()
+  }
+
+  val tableName = "development.testobjects"// fixme get from config
+
+  def initTable(): Unit = {
+    val primaryKey = "id"
+    val attributeDefinitions: Seq[AttributeDefinition] = Seq(new AttributeDefinition(primaryKey, ScalarAttributeType.S))
+    val keySchemaElements: Seq[KeySchemaElement] = Seq(new KeySchemaElement(primaryKey, KeyType.HASH))
+    val provisionedThroughput = new ProvisionedThroughput(1000L, 1000L)
+    val streamSpecification = new StreamSpecification()
+      .withStreamEnabled(true)
+      .withStreamViewType(StreamViewType.NEW_AND_OLD_IMAGES)
+    val request = new CreateTableRequest()
+      .withTableName(tableName)
+      .withAttributeDefinitions(attributeDefinitions: _*)
+      .withKeySchema(keySchemaElements: _*)
+      .withProvisionedThroughput(provisionedThroughput)
+      .withStreamSpecification(streamSpecification)
+    dynamoDBClient.createTable(request)
+    ()
+  }
+
+  def withConfig[T](f: MockConfig => T)(implicit app: Application): T = {
+    val c = config
+    c.set("name", "lib-event-test")
+    f(c)
+  }
+
+  def withMockQueue[T](f: DynamoStreamQueue => T): T = {
+    val rollbar = RollbarLogger.SimpleLogger
+    f(new MockDynamoStreamQueue(rollbar))
+  }
+
+  def withIntegrationQueue[T](f: DynamoStreamQueue => T)(implicit app: Application): T = {
+    withConfig { config =>
+      val creds = new AWSCreds(config)
+      val endpoints = app.injector.instanceOf[AWSEndpoints]
+      val metrics = new MockMetricsSystem()
+      val rollbar = RollbarLogger.SimpleLogger
+
+      f(new DefaultDynamoStreamQueue(config, creds, endpoints, metrics, rollbar))
+    }
+  }
+
+  def publishTestObject(obj: TestObject): String = {
+    val item = Map("id" -> new AttributeValue().withS(obj.id)).asJava
+    dynamoDBClient.putItem(tableName, item)
+    publishCount.incrementAndGet().toString
+  }
+
+  def publishTestObject(producer: Producer[TestObjectUpserted], obj: TestObjectUpserted): String = {
+    producer.publish(obj)
+    obj.eventId
+  }
+
+  def consume[T: TypeTag](q: Queue, eventId: String, timeoutSeconds: Int = 120): Record = {
+    consumeUntil[T](q, eventId, timeoutSeconds).find(_.eventId == eventId).getOrElse {
+      sys.error(s"Failed to find eventId[$eventId]")
+    }
+  }
+
+  def consumeUntil[T: TypeTag](q: Queue, eventId: String, timeoutSeconds: Int = 120): Seq[Record] = {
+    val all = scala.collection.mutable.ListBuffer[Record]()
+    q.consume[T] { recs =>
+      all ++= recs
+    }
+
+    Await.result(
+      Future {
+        while (!all.exists(_.eventId == eventId)) {
+          Thread.sleep(100)
+        }
+      },
+      timeoutSeconds.toLong.seconds
+    )
+
+    q.shutdown()
+
+    all.toSeq
+  }
+}

--- a/test/io/flow/event/v2/DynamoStreamQueueSpec.scala
+++ b/test/io/flow/event/v2/DynamoStreamQueueSpec.scala
@@ -1,0 +1,70 @@
+package io.flow.event.v2
+
+import com.amazonaws.services.dynamodbv2.model.AttributeValue
+import io.flow.event.{DynamoStreamEventName, DynamoStreamRecord}
+import io.flow.lib.event.test.v0.mock.Factories
+import io.flow.lib.event.test.v0.models.json._
+import io.flow.lib.event.test.v0.models.{TestObject, TestObjectUpserted}
+import io.flow.play.clients.ConfigModule
+import org.scalatest.BeforeAndAfterAll
+import org.scalatestplus.play.PlaySpec
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
+
+import scala.reflect.runtime.universe._
+
+class DynamoStreamQueueSpec extends PlaySpec with GuiceOneAppPerSuite
+  with DynamoStreamHelpers
+  with KinesisIntegrationSpec
+  with BeforeAndAfterAll {
+
+  override def fakeApplication(): Application =
+    new GuiceApplicationBuilder()
+      .bindings(new ConfigModule)
+      .build()
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    initTable()
+  }
+
+  "default dynamo queue prevents publishing" in {
+    withIntegrationQueue { q =>
+      a [RuntimeException] must be thrownBy q.producer[TestObjectUpserted]()
+    }
+  }
+
+  "can publish and consume an event using mock" in {
+    withMockQueue { q =>
+      val testObject = Factories.makeTestObjectUpserted()
+      val producer = q.producer[TestObjectUpserted]()
+      val eventId = publishTestObject(producer, testObject)
+      println(s"Published object[$eventId]. Waiting for consumer")
+
+      val fetched = consume[TestObjectUpserted](q, eventId)
+      fetched.js.as[TestObjectUpserted].testObject.id must equal(testObject.testObject.id)
+
+      q.shutdown()
+    }
+  }
+
+  "can consume an event" in {
+    withIntegrationQueue { q =>
+      val testObject = Factories.makeTestObject()
+      val eventId = publishTestObject(testObject)
+      println(s"Published object[$eventId]. Waiting for consumer")
+
+      val fetched = consume[TestObject](q, eventId)
+      fetched.isInstanceOf[DynamoStreamRecord] must be (true)
+      val record = fetched.asInstanceOf[DynamoStreamRecord]
+      record.eventName must be (DynamoStreamEventName.Insert)
+      record.recordType must be (typeOf[TestObject])
+      record.discriminator must be (Some("TestObject"))
+      record.newImage must not be (empty)
+      record.newImage("id") must be (new AttributeValue(testObject.id))
+
+      q.shutdown()
+    }
+  }
+}

--- a/test/io/flow/event/v2/DynamoStreamQueueSpec.scala
+++ b/test/io/flow/event/v2/DynamoStreamQueueSpec.scala
@@ -56,7 +56,7 @@ class DynamoStreamQueueSpec extends PlaySpec with GuiceOneAppPerSuite
       record.recordType must be (typeOf[TestObject])
       record.discriminator must be (Some("TestObject"))
       record.newImage must not be (empty)
-      record.newImage("id") must be (new AttributeValue(testObject.id))
+      record.newImage.get.get("id") must be (new AttributeValue(testObject.id))
 
       q.shutdown()
     }

--- a/test/io/flow/event/v2/KinesisIntegrationSpec.scala
+++ b/test/io/flow/event/v2/KinesisIntegrationSpec.scala
@@ -1,7 +1,7 @@
 package io.flow.event.v2
 
 import cloud.localstack.Localstack
-import cloud.localstack.ServiceName.{DYNAMO, KINESIS}
+import cloud.localstack.ServiceName.{CLOUDWATCH, DYNAMO, DYNAMO_STREAMS, KINESIS}
 import cloud.localstack.docker.annotation.LocalstackDockerConfiguration
 import org.scalatest.{BeforeAndAfterAll, Suite}
 
@@ -16,7 +16,7 @@ trait KinesisIntegrationSpec extends BeforeAndAfterAll { this: Suite =>
     val imagePresent = ("docker images" #| "grep localstack" !) == 0
 
     val conf = LocalstackDockerConfiguration.builder()
-      .environmentVariables(Map("SERVICES" -> s"$KINESIS,$DYNAMO").asJava)
+      .environmentVariables(Map("SERVICES" -> s"$KINESIS,$DYNAMO,$DYNAMO_STREAMS,$CLOUDWATCH").asJava)
       .pullNewImage(!imagePresent)
       .build()
 


### PR DESCRIPTION
Uses the Amazon Kinesis adapter for easy reading from DynamoDB stream and ties in with our event processing framework.