### PR TITLE
Properly SnakeCase Dynamo Table Names

### DIFF
--- a/app/io/flow/event/v2/DynamoStreamQueue.scala
+++ b/app/io/flow/event/v2/DynamoStreamQueue.scala
@@ -75,8 +75,7 @@ class DefaultDynamoStreamQueue @Inject() (
 
   private[v2] def tableName[T: TypeTag] = s"${FlowEnvironment.Current}.${tableNameFromType[T]}s"
   private def tableNameFromType[T: TypeTag]: String = {
-    val name = typeOf[T].toString
-    val typ = name.split("\\.").takeRight(1).mkString("")
+    val typ = typeOf[T].typeSymbol.name.toString
     StreamNames.toSnakeCase(typ)
   }
 }

--- a/app/io/flow/event/v2/DynamoStreamQueue.scala
+++ b/app/io/flow/event/v2/DynamoStreamQueue.scala
@@ -6,7 +6,7 @@ import io.flow.event.Record
 import io.flow.log.RollbarLogger
 import io.flow.play.metrics.MetricsSystem
 import io.flow.play.util.Config
-import io.flow.util.FlowEnvironment
+import io.flow.util.{FlowEnvironment, StreamNames}
 import javax.inject.{Inject, Singleton}
 
 import scala.concurrent.duration._
@@ -71,9 +71,14 @@ class DefaultDynamoStreamQueue @Inject() (
       endpoints = endpoints
     )
   }
+  import scala.reflect.runtime.universe._
 
-  private def tableName[T: TypeTag] = s"${FlowEnvironment.Current}.${typeName[T]}s"
-  private def typeName[T: TypeTag] = typeOf[T].typeSymbol.name.toString.toLowerCase
+  private[v2] def tableName[T: TypeTag] = s"${FlowEnvironment.Current}.${tableNameFromType[T]}s"
+  private def tableNameFromType[T: TypeTag]: String = {
+    val name = typeOf[T].toString
+    val typ = name.split("\\.").takeRight(1).mkString("")
+    StreamNames.toSnakeCase(typ)
+  }
 }
 
 @Singleton

--- a/app/io/flow/event/v2/DynamoStreamQueue.scala
+++ b/app/io/flow/event/v2/DynamoStreamQueue.scala
@@ -71,7 +71,6 @@ class DefaultDynamoStreamQueue @Inject() (
       endpoints = endpoints
     )
   }
-  import scala.reflect.runtime.universe._
 
   private[v2] def tableName[T: TypeTag] = s"${FlowEnvironment.Current}.${tableNameFromType[T]}s"
   private def tableNameFromType[T: TypeTag]: String = {

--- a/test/io/flow/event/v2/DynamoStreamQueueSpec.scala
+++ b/test/io/flow/event/v2/DynamoStreamQueueSpec.scala
@@ -15,7 +15,10 @@ import scala.reflect.runtime.universe._
 
 class DynamoStreamQueueSpec extends PlaySpec with GuiceOneAppPerSuite
   with DynamoStreamHelpers
-  with KinesisIntegrationSpec {
+  with KinesisIntegrationSpec
+{
+
+  def dynamoStreamQueue(implicit app: Application) = app.injector.instanceOf[DefaultDynamoStreamQueue]
 
   override def fakeApplication(): Application =
     new GuiceApplicationBuilder()
@@ -60,5 +63,9 @@ class DynamoStreamQueueSpec extends PlaySpec with GuiceOneAppPerSuite
 
       q.shutdown()
     }
+  }
+
+  "table name" in {
+    dynamoStreamQueue.tableName[TestObject] must equal("development.test_objects")
   }
 }


### PR DESCRIPTION
Fixes:
```
Error injecting constructor, com.amazonaws.services.dynamodbv2.model.ResourceNotFoundException:
  Requested resource not found: 
    Table: production.checkoutrequests not found (
      Service: AmazonDynamoDBv2; 
      Status Code: 400; 
      Error Code: ResourceNotFoundException
...
...
```

Expectation is that the Dynamo table name is configured as: `production.checkout_requests`