### PR TITLE
Allow Kinesis region to be specified

### DIFF
--- a/app/io/flow/event/v2/AWSConfig.scala
+++ b/app/io/flow/event/v2/AWSConfig.scala
@@ -28,6 +28,8 @@ class AWSCreds @Inject() (config: Config) extends AWSCredentialsProviderChain(
   * We run local versions of kinesis and dynamodb for testing through https://github.com/localstack/localstack
   */
 class AWSEndpoints @Inject() (environment: Environment) {
+
+  // only for local tests
   val region = "us-east-1"
 
   val kinesis = environment.mode match {

--- a/app/io/flow/event/v2/Queue.scala
+++ b/app/io/flow/event/v2/Queue.scala
@@ -131,6 +131,7 @@ class DefaultQueue @Inject() (
       idleTimeBetweenReadsInMillis = config.optionalLong(s"$sn.idleTimeBetweenReadsMs"),
       maxLeasesForWorker = config.optionalInt(s"$sn.maxLeasesForWorker"),
       maxLeasesToStealAtOneTime = config.optionalInt(s"$sn.maxLeasesToStealAtOneTime"),
+      region = config.optionalString("aws.kinesis.region"),
       endpoints = endpoints,
     )
   }

--- a/app/io/flow/event/v2/StreamConfig.scala
+++ b/app/io/flow/event/v2/StreamConfig.scala
@@ -91,6 +91,8 @@ case class DefaultStreamConfig(
   idleTimeBetweenReadsInMillis: Option[Long],
   maxLeasesForWorker: Option[Int],
   maxLeasesToStealAtOneTime: Option[Int],
+  // if not provided, uses the default region provider chain
+  region: Option[String],
   eventClass: Type,
   endpoints: AWSEndpoints,
 ) extends StreamConfig {
@@ -105,6 +107,7 @@ case class DefaultStreamConfig(
           .withThrottledRetries(true)
           .withConnectionTTL(600000)
       )
+    region.foreach(kclb.setRegion)
 
     endpoints.kinesis.foreach { ep =>
       kclb.setEndpointConfiguration(new EndpointConfiguration(ep, endpoints.region))

--- a/conf/reference.conf
+++ b/conf/reference.conf
@@ -1,1 +1,3 @@
+aws.kinesis.region=${?AWS_KINESIS_REGION}
+
 play.modules.enabled += "io.flow.play.metrics.MetricsModule"


### PR DESCRIPTION
This change allows the Kinesis region to be specified instead of relying on the default region provider chain.


To change the region, services can provide the `AWS_KINESIS_REGION` variable or update the `aws.kinesis.region` configuration variable.