### PR TITLE
Upgrade libraries cloud.localstack, io.flow

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,19 +15,19 @@ lazy val root = project
     libraryDependencies ++= Seq(
       ws,
       guice,
-      "io.flow" %% "lib-akka-akka26" % "0.1.45",
-      "io.flow" %% "lib-play-graphite-play28" % "0.1.90",
+      "io.flow" %% "lib-akka-akka26" % "0.1.47",
+      "io.flow" %% "lib-play-graphite-play28" % "0.1.91",
       "com.amazonaws" % "amazon-kinesis-client" % "1.14.2",
       "com.amazonaws" % "dynamodb-streams-kinesis-adapter" % "1.5.2",
       "software.amazon.kinesis" % "amazon-kinesis-client" % "2.3.4",
       // evict aws dependency on allegedly incompatible "jackson-dataformat-cbor" % "2.6.7",
       "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % "2.10.3",
       "org.mockito" % "mockito-core" % "3.9.0" % Test,
-      "io.flow" %% "lib-test-utils-play28" % "0.1.27" % Test,
+      "io.flow" %% "lib-test-utils-play28" % "0.1.29" % Test,
       "org.scalatestplus" %% "mockito-3-2" % "3.1.2.0" % Test,
       compilerPlugin("com.github.ghik" %% "silencer-plugin" % "1.7.3" cross CrossVersion.full),
       "com.github.ghik" %% "silencer-lib" % "1.7.3" % Provided cross CrossVersion.full,
-      "cloud.localstack" % "localstack-utils" % "0.2.10" % Test
+      "cloud.localstack" % "localstack-utils" % "0.2.11" % Test
     ),
     resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/",
     resolvers += "scalaz-bintray" at "https://dl.bintray.com/scalaz/releases",


### PR DESCRIPTION
- cloud.localstack
  - localstack-utils (0.2.10 => 0.2.11)
- io.flow
  - lib-akka-akka26 (0.1.45 => 0.1.47)
  - lib-play-graphite-play28 (0.1.90 => 0.1.91)
  - lib-test-utils-play28 (0.1.27 => 0.1.29)